### PR TITLE
Update com.android.support libs to androidx. Update test dependencies.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,20 +172,19 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation(
-            'com.android.support:support-v4:' + androidSupportVersion,
-            'com.android.support:appcompat-v7:' + androidSupportVersion,
-            'com.android.support:design:' + androidSupportVersion,
-            'com.android.support:cardview-v7:' + androidSupportVersion,
-            'com.android.support:preference-v7:' + androidSupportVersion,
-            'com.android.support:recyclerview-v7:' + androidSupportVersion,
+            'androidx.legacy:legacy-support-v4:1.0.0',
+            'androidx.appcompat:appcompat:1.6.1',
+            'com.google.android.material:material:1.9.0',
+            'androidx.cardview:cardview:1.0.0',
+            'androidx.preference:preference:1.2.0',
+            'androidx.recyclerview:recyclerview:1.3.0'
     )
 
     implementation 'net.objecthunter:exp4j:0.4.7'
-    implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
+    implementation 'androidx.drawerlayout:drawerlayout:1.2.0'
     implementation 'androidx.multidex:multidex:2.0.1'
 
     implementation 'com.google.android.gms:play-services-drive:17.0.0'
-    implementation 'com.google.android.material:material:1.8.0'
 
     implementation platform('com.google.firebase:firebase-bom:31.2.1')
     implementation 'com.google.firebase:firebase-crashlytics'
@@ -219,21 +218,21 @@ dependencies {
     testImplementation 'org.robolectric:shadows-multidex:3.0'
 }
 
-def androidSupportTestVersion = "1.0.0"
-def androidEspressoVersion = "3.0.0"
+def androidEspressoVersion = "3.5.1"
 dependencies {
-    androidTestImplementation 'com.android.support:support-annotations:' + androidSupportVersion
+    androidTestImplementation 'androidx.annotation:annotation-experimental:1.3.0'
     //the following are only added so that the app and test version both us the same versions
-    androidTestImplementation 'com.android.support:appcompat-v7:' + androidSupportVersion
-    androidTestImplementation 'com.android.support:design:' + androidSupportVersion
+    androidTestImplementation 'com.google.android.material:material:1.9.0'
 
-    androidTestImplementation 'com.android.support.test:runner:' + androidSupportTestVersion
-    androidTestImplementation 'com.android.support.test:rules:' + androidSupportTestVersion
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
 
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:' + androidEspressoVersion
-    androidTestImplementation 'com.android.support.test.espresso:espresso-intents:' + androidEspressoVersion
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
-    androidTestImplementation('com.android.support.test.espresso:espresso-contrib:' + androidEspressoVersion) {
+    androidTestImplementation 'androidx.test.espresso:espresso-core:' + androidEspressoVersion
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:' + androidEspressoVersion
+    androidTestImplementation('androidx.test.espresso:espresso-contrib:' + androidEspressoVersion) {
         exclude group: 'com.android.support', module: 'support-v4'
         exclude module: 'recyclerview-v7'
     }

--- a/app/proguard-project.txt
+++ b/app/proguard-project.txt
@@ -23,7 +23,7 @@
     protected Object[][] getContents();
 }
 
--keep class android.support.v7.widget.SearchView { *; }
+-keep class androidx.appcompat.widget.SearchView { *; }
 
 -keep public class com.google.android.gms.common.internal.safeparcel.SafeParcelable {
     public static final *** NULL;

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -13,4 +13,4 @@
 
 -keep class org.gnucash.android.** {*;}
 -keep class com.dropbox.** {*;}
--keep class android.support.v7.widget.SearchView { *; }
+-keep class androidx.appcompat.widget.SearchView { *; }

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/AccountsActivityTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/AccountsActivityTest.java
@@ -58,7 +58,7 @@ import androidx.test.espresso.Espresso;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.kobakei.ratethisapp.RateThisApp;
 

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/CalculatorEditTextTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/CalculatorEditTextTest.java
@@ -32,7 +32,7 @@ import android.util.Log;
 
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/ExportTransactionsTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/ExportTransactionsTest.java
@@ -36,7 +36,7 @@ import android.util.Log;
 import androidx.test.espresso.contrib.DrawerActions;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
@@ -77,7 +77,7 @@ public class ExportTransactionsTest {
     public GrantPermissionRule animationPermissionsRule = GrantPermissionRule.grant(Manifest.permission.SET_ANIMATION_SCALE);
 
     @Rule
-    ActivityTestRule<AccountsActivity> rule = new ActivityTestRule<>(AccountsActivity.class);
+    public ActivityTestRule<AccountsActivity> rule = new ActivityTestRule<>(AccountsActivity.class);
 
     @Before
     public void setUp() throws Exception {

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/FirstRunWizardActivityTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/FirstRunWizardActivityTest.java
@@ -30,7 +30,7 @@ import android.util.Log;
 
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
@@ -61,7 +61,7 @@ public class FirstRunWizardActivityTest {
     FirstRunWizardActivity mActivity;
 
     @Rule
-    ActivityTestRule<FirstRunWizardActivity> rule = new ActivityTestRule<>(FirstRunWizardActivity.class);
+    public ActivityTestRule<FirstRunWizardActivity> rule = new ActivityTestRule<>(FirstRunWizardActivity.class);
 
     @Rule
     public GrantPermissionRule animationPermissionsRule = GrantPermissionRule.grant(Manifest.permission.SET_ANIMATION_SCALE);

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/MultiBookTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/MultiBookTest.java
@@ -34,7 +34,7 @@ import androidx.test.espresso.contrib.DrawerActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.gnucash.android.R;
 import org.gnucash.android.db.adapter.BooksDbAdapter;

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/OwnCloudExportTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/OwnCloudExportTest.java
@@ -16,7 +16,6 @@
 
 package org.gnucash.android.test.ui;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -28,6 +27,7 @@ import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.gnucash.android.test.ui.AccountsActivityTest.preventFirstRunDialogs;
@@ -47,7 +47,7 @@ import androidx.test.espresso.Espresso;
 import androidx.test.espresso.contrib.DrawerActions;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
@@ -169,7 +169,7 @@ public class OwnCloudExportTest {
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
         onView(withId(R.id.nav_view)).perform(swipeUp());
         onView(withText(R.string.title_settings)).perform(click());
-        onView(withText(R.string.header_backup_and_export_settings)).perform(click());
+//        onView(withText(R.string.header_backup_and_export_settings)).perform(click());
         onView(withText(R.string.title_owncloud_sync_preference)).perform(click());
         onView(withId(R.id.owncloud_hostname)).check(matches(isDisplayed()));
 

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/PieChartReportTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/PieChartReportTest.java
@@ -34,7 +34,7 @@ import androidx.test.espresso.action.Press;
 import androidx.test.espresso.action.Tap;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
 
 import android.Manifest;
+import android.app.UiAutomation;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
@@ -40,9 +41,14 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 
 import androidx.test.espresso.Espresso;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
+
+import com.google.android.gms.common.util.UidVerifier;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
@@ -65,6 +71,7 @@ import org.gnucash.android.ui.settings.PreferenceActivity;
 import org.gnucash.android.ui.transaction.TransactionFormFragment;
 import org.gnucash.android.ui.transaction.TransactionsActivity;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -200,8 +207,6 @@ public class TransactionsActivityTest {
                 .perform(click());
         onView(withText(R.string.title_add_transaction)).check(matches(isDisplayed()));
 
-        sleep(1000);
-
         assertToastDisplayed(R.string.toast_transanction_amount_required);
 
         int afterCount = mTransactionsDbAdapter.getTransactionsCount(TRANSACTIONS_ACCOUNT_UID);
@@ -228,6 +233,7 @@ public class TransactionsActivityTest {
      * @param toastString String that should be displayed
      */
     private void assertToastDisplayed(int toastString) {
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle();
         onView(withText(toastString))
                 .inRoot(withDecorView(not(mTransactionsActivity.getWindow().getDecorView())))
                 .check(matches(isDisplayed()));

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/util/DisableAnimationsRule.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/util/DisableAnimationsRule.java
@@ -1,40 +1,51 @@
 package org.gnucash.android.test.ui.util;
 
-import android.os.IBinder;
+import android.app.UiAutomation;
+import android.net.TrafficStats;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
 
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.gnucash.android.test.ui.TransactionsActivityTest;
+import org.gnucash.android.ui.transaction.TransactionsActivity;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import java.lang.reflect.Method;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Created by Ngewi on 19.04.2016.
  * Credit: <a href="https://product.reverb.com/2015/06/06/disabling-animations-in-espresso-for-android-testing/">reverb.com</a>
  */
 public class DisableAnimationsRule implements TestRule {
-    private Method mSetAnimationScalesMethod;
-    private Method mGetAnimationScalesMethod;
-    private Object mWindowManagerObject;
+    private void setAnimationState(AnimationState state) throws IOException {
+        List<String> commands = List.of(
+                "settings get global animator_duration_scale",
+                "settings put global animator_duration_scale " + state.getStatusCode(),
+                "settings put global transition_animation_scale " + state.getStatusCode(),
+                "settings put global window_animation_scale " + state.getStatusCode()
+        );
 
-    public DisableAnimationsRule() {
-        try {
-            Class<?> windowManagerStubClazz = Class.forName("android.view.IWindowManager$Stub");
-            Method asInterface = windowManagerStubClazz.getDeclaredMethod("asInterface", IBinder.class);
+        UiAutomation uiAutomation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
+        uiAutomation.adoptShellPermissionIdentity("android.permission.WRITE_SECURE_SETTINGS");
 
-            Class<?> serviceManagerClazz = Class.forName("android.os.ServiceManager");
-            Method getService = serviceManagerClazz.getDeclaredMethod("getService", String.class);
-
-            Class<?> windowManagerClazz = Class.forName("android.view.IWindowManager");
-
-            mSetAnimationScalesMethod = windowManagerClazz.getDeclaredMethod("setAnimationScales", float[].class);
-            mGetAnimationScalesMethod = windowManagerClazz.getDeclaredMethod("getAnimationScales");
-
-            IBinder windowManagerBinder = (IBinder) getService.invoke(null, "window");
-            mWindowManagerObject = asInterface.invoke(null, windowManagerBinder);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to access animation methods", e);
+        for (String command : commands) {
+            try (
+                    ParcelFileDescriptor fd = uiAutomation.executeShellCommand(command);
+                    InputStream is = new BufferedInputStream(new FileInputStream(fd.getFileDescriptor()));
+                    fd;
+                    is
+            ) {
+                Log.d(DisableAnimationsRule.class.getSimpleName(), new String(is.readAllBytes()));
+            }
         }
     }
 
@@ -43,19 +54,31 @@ public class DisableAnimationsRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                setAnimationScaleFactors(0.0f);
+                setAnimationState(AnimationState.DISABLED);
                 try {
                     statement.evaluate();
                 } finally {
-                    setAnimationScaleFactors(1.0f);
+                    setAnimationState(AnimationState.DEFAULT);
                 }
             }
         };
     }
 
-    private void setAnimationScaleFactors(float scaleFactor) throws Exception {
-        float[] scaleFactors = (float[]) mGetAnimationScalesMethod.invoke(mWindowManagerObject);
-        Arrays.fill(scaleFactors, scaleFactor);
-        mSetAnimationScalesMethod.invoke(mWindowManagerObject, scaleFactors);
+    private enum AnimationState {
+        DISABLED(AnimationState.ANIMATIONS_DISABLED),
+        DEFAULT(AnimationState.ANIMATIONS_DEFAULT);
+
+        private final float statusCode;
+
+        AnimationState(float statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        public float getStatusCode() {
+            return statusCode;
+        }
+
+        private static final float ANIMATIONS_DISABLED = 0.0f;
+        private static final float ANIMATIONS_DEFAULT = 1.0f;
     }
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -16,6 +16,8 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:enableOnBackInvokedCallback="true"/>
    <!-- Disable animations on debug builds so that the animations do not interfere with Espresso
          tests.  Adding this permission to the manifest is not sufficient - you must also grant the
          permission over adb! -->

--- a/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
+++ b/app/src/main/java/org/gnucash/android/app/GnuCashApplication.java
@@ -343,12 +343,12 @@ public class GnuCashApplication extends MultiDexApplication {
         Intent alarmIntent = new Intent(context, PeriodicJobReceiver.class);
         alarmIntent.setAction(PeriodicJobReceiver.ACTION_SCHEDULED_ACTIONS);
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent,
-                PendingIntent.FLAG_NO_CREATE);
+                PendingIntent.FLAG_NO_CREATE | PendingIntent.FLAG_MUTABLE);
 
         if (pendingIntent != null) //if service is already scheduled, just return
             return;
         else
-            pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, 0);
+            pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, PendingIntent.FLAG_MUTABLE);
 
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         alarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP,

--- a/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
@@ -754,7 +754,7 @@ public class MigrationHelper {
                 //cancel existing pending intent
                 Context context = GnuCashApplication.getAppContext();
                 PendingIntent recurringPendingIntent = PendingIntent.getBroadcast(context,
-                        (int) transactionId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                        (int) transactionId, intent, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
                 AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
                 alarmManager.cancel(recurringPendingIntent);
             }

--- a/app/src/main/java/org/gnucash/android/util/BackupManager.java
+++ b/app/src/main/java/org/gnucash/android/util/BackupManager.java
@@ -187,7 +187,7 @@ public class BackupManager {
         Intent intent = new Intent(context, PeriodicJobReceiver.class);
         intent.setAction(PeriodicJobReceiver.ACTION_BACKUP);
         PendingIntent alarmIntent = PendingIntent.getBroadcast(context, 0, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         alarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP,
                 SystemClock.elapsedRealtime() + AlarmManager.INTERVAL_FIFTEEN_MINUTES,

--- a/app/src/main/res/menu/global_actions.xml
+++ b/app/src/main/res/menu/global_actions.xml
@@ -22,6 +22,6 @@
         android:title="@string/menu_search_accounts"
         android:icon="@drawable/ic_search_white_24dp"
         app:showAsAction="collapseActionView|ifRoom"
-        app:actionViewClass="android.support.v7.widget.SearchView" />
+        app:actionViewClass="androidx.appcompat.widget.SearchView" />
 
 </menu>


### PR DESCRIPTION
All the com.android.support libs were replaced by their androidx counterparts and had their versions bumped up.

Deprecated `androidx.test.runner.AndroidJUnit4` is replaced by `androidx.test.ext.junit.runners.AndroidJUnit4` (which now belongs in a separate lib).

Animation scale can no longer be set by `mSetAnimationScalesMethod = windowManagerClazz.getDeclaredMethod("setAnimationScales", float[].class);`, as this method is not present in newer APIs (`android.permission.SET_ANIMATION_SCALE` itself is now a protected permission, restricted to system processes). Instead, `UiAutomation.executeShellCommand(command)` is used for this purpose, with the required permission acquired by UiAutomator at the moment they are needed.

There are still broken tests (wip), but this PR fixes a few of them.