### PR TITLE
Remove software keyboard from fragment_transaction_form.xml.

### DIFF
--- a/app/src/androidTest/java/org/gnucash/android/test/ui/CalculatorEditTextTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/CalculatorEditTextTest.java
@@ -20,19 +20,28 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withInputType;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import android.Manifest;
+import android.app.UiAutomation;
 import android.content.Intent;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
+import android.text.InputType;
 import android.util.Log;
 
+import androidx.test.espresso.action.ViewActions;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.uiautomator.UiDevice;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
@@ -45,10 +54,12 @@ import org.gnucash.android.db.adapter.TransactionsDbAdapter;
 import org.gnucash.android.model.Account;
 import org.gnucash.android.model.Commodity;
 import org.gnucash.android.test.ui.util.DisableAnimationsRule;
+import org.gnucash.android.test.ui.util.SoftwareKeyboard;
 import org.gnucash.android.ui.common.UxArgument;
 import org.gnucash.android.ui.transaction.TransactionsActivity;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -141,21 +152,24 @@ public class CalculatorEditTextTest {
     public void testShowingHidingOfCalculatorKeyboard() {
         clickOnView(R.id.fab_create_transaction);
 
+        // Verify the input type is correct
+        onView(withId(R.id.input_transaction_amount)).check(matches(allOf(withInputType(InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_CLASS_NUMBER))));
+
         // Giving the focus to the amount field shows the keyboard
         onView(withId(R.id.input_transaction_amount)).perform(click());
-        onView(withId(R.id.calculator_keyboard)).check(matches(isDisplayed()));
+        assertThat(SoftwareKeyboard.isKeyboardOpen(), is(true));
 
         // Pressing back hides the keyboard (still with focus)
         pressBack();
-        onView(withId(R.id.calculator_keyboard)).check(matches(not(isDisplayed())));
+        assertThat(SoftwareKeyboard.isKeyboardOpen(), is(false));
 
         // Clicking the amount field already focused shows the keyboard again
         clickOnView(R.id.input_transaction_amount);
-        onView(withId(R.id.calculator_keyboard)).check(matches(isDisplayed()));
+        assertThat(SoftwareKeyboard.isKeyboardOpen(), is(true));
 
-        // Changing the focus to another field hides the keyboard
+        // Changing the focus to another field keeps the software keyboard open
         clickOnView(R.id.input_transaction_name);
-        onView(withId(R.id.calculator_keyboard)).check(matches(not(isDisplayed())));
+        assertThat(SoftwareKeyboard.isKeyboardOpen(), is(true));
     }
 
     /**

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/util/SoftwareKeyboard.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/util/SoftwareKeyboard.java
@@ -1,0 +1,21 @@
+package org.gnucash.android.test.ui.util;
+
+import android.util.Log;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+
+import java.io.IOException;
+
+public class SoftwareKeyboard {
+    public static boolean isKeyboardOpen() {
+        String command = "dumpsys input_method | grep mInputShown";
+        try {
+            return UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).executeShellCommand(command).contains("mInputShown=true");
+        } catch (IOException e) {
+            Log.e(SoftwareKeyboard.class.getSimpleName(),  Log.getStackTraceString(e), e);
+            throw new RuntimeException("Keyboard state cannot be read", e);
+
+        }
+    }
+}

--- a/app/src/main/java/org/gnucash/android/ui/export/ExportFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/export/ExportFormFragment.java
@@ -513,7 +513,7 @@ public class ExportFormFragment extends Fragment implements
         };
 
         View v = getView();
-        assert v != null;
+        if(v == null) return;
 
         mOfxRadioButton.setOnClickListener(radioClickListener);
         mQifRadioButton.setOnClickListener(radioClickListener);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -22,7 +22,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.database.Cursor;
-import android.inputmethodservice.KeyboardView;
 import android.os.Bundle;
 import android.text.format.DateUtils;
 import android.util.Log;
@@ -56,6 +55,7 @@ import com.codetroopers.betterpickers.radialtimepicker.RadialTimePickerDialogFra
 import com.codetroopers.betterpickers.recurrencepicker.EventRecurrence;
 import com.codetroopers.betterpickers.recurrencepicker.EventRecurrenceFormatter;
 import com.codetroopers.betterpickers.recurrencepicker.RecurrencePickerDialogFragment;
+import com.google.android.material.snackbar.Snackbar;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
@@ -202,12 +202,6 @@ public class TransactionFormFragment extends Fragment implements
     TextView mRecurrenceTextView;
 
     /**
-     * View which displays the calculator keyboard
-     */
-    @BindView(R.id.calculator_keyboard)
-    KeyboardView mKeyboardView;
-
-    /**
      * Open the split editor
      */
     @BindView(R.id.btn_split_editor)
@@ -270,13 +264,13 @@ public class TransactionFormFragment extends Fragment implements
                              Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_transaction_form, container, false);
         ButterKnife.bind(this, v);
-        mAmountEditText.bindListeners(mKeyboardView);
         mOpenSplitEditor.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 openSplitEditor();
             }
         });
+
         return v;
     }
 
@@ -306,7 +300,6 @@ public class TransactionFormFragment extends Fragment implements
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        mAmountEditText.bindListeners(mKeyboardView);
     }
 
     @Override
@@ -546,7 +539,6 @@ public class TransactionFormFragment extends Fragment implements
     private void toggleAmountInputEntryMode(boolean enabled) {
         if (enabled) {
             mAmountEditText.setFocusable(true);
-            mAmountEditText.bindListeners(mKeyboardView);
         } else {
             mAmountEditText.setFocusable(false);
             mAmountEditText.setOnClickListener(new View.OnClickListener() {
@@ -856,8 +848,6 @@ public class TransactionFormFragment extends Fragment implements
      * and save a transaction
      */
     private void saveNewTransaction() {
-        mAmountEditText.getCalculatorKeyboard().hideCustomKeyboard();
-
         //determine whether we need to do currency conversion
 
         if (isMultiCurrencyTransaction() && !splitEditorUsed() && !mCurrencyConversionDone) {
@@ -964,16 +954,18 @@ public class TransactionFormFragment extends Fragment implements
                 return true;
 
             case R.id.menu_save:
+                View parentLayout = getActivity().findViewById(android.R.id.content);
+
                 if (canSave()) {
                     saveNewTransaction();
                 } else {
                     if (mAmountEditText.getValue() == null) {
-                        Toast.makeText(getActivity(), R.string.toast_transanction_amount_required, Toast.LENGTH_SHORT).show();
+                        Snackbar.make(parentLayout, R.string.toast_transanction_amount_required, Snackbar.LENGTH_LONG).show();
                     }
                     if (mUseDoubleEntry && mTransferAccountSpinner.getCount() == 0) {
-                        Toast.makeText(getActivity(),
+                        Snackbar.make(parentLayout,
                                 R.string.toast_disable_double_entry_to_save_transaction,
-                                Toast.LENGTH_LONG).show();
+                                Snackbar.LENGTH_LONG).show();
                     }
                 }
                 return true;

--- a/app/src/main/res/layout/fragment_transaction_form.xml
+++ b/app/src/main/res/layout/fragment_transaction_form.xml
@@ -72,7 +72,7 @@
                     android:layout_weight="3"
                     android:layout_height="wrap_content"
                     android:hint="@string/label_transaction_amount"
-                    android:inputType="none"
+                    android:inputType="numberDecimal"
                     android:singleLine="true"
                     android:nextFocusDown="@+id/input_description"
                     android:background="@android:color/transparent"
@@ -190,15 +190,4 @@
             <!-- Not exposing the transaction template checkbox to the UI at this time -->
         </TableLayout>
     </ScrollView>
-
-    <android.inputmethodservice.KeyboardView
-        android:id="@+id/calculator_keyboard"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentRight="true"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
-        android:visibility="gone" />
 </RelativeLayout>


### PR DESCRIPTION
Replace the old CalculatorKeyboard in transaction_form by a regular software keyboard and set the `inputType` of transaction amount edit text to `numberDecimal`. 

|Before|After|
|---|---|
| ![Screenshot_1685397664](https://github.com/GnuCash-Pocket/gnucash-android/assets/316087/7d1eea05-435e-4a95-be6f-c24fcf22ed15) | ![Screenshot_1685397639](https://github.com/GnuCash-Pocket/gnucash-android/assets/316087/4cf16cb7-23bb-4934-8214-8cfb48e682a1) |

