### PR TITLE
Cleanup all transactions at beginning of TransactionsActivityTest.testAddMultiCurrencyTransaction()

### DIFF
--- a/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
@@ -292,6 +292,8 @@ public class TransactionsActivityTest {
 
     @Test
     public void testAddMultiCurrencyTransaction() {
+        mTransactionsDbAdapter.deleteTransactionsForAccount(TRANSACTIONS_ACCOUNT_UID);
+
         Commodity euro = Commodity.getInstance("EUR");
         Account euroAccount = new Account("Euro Konto", euro);
         mAccountsDbAdapter.addRecord(euroAccount);


### PR DESCRIPTION
Some other test sometimes leaves one transaction in the account referred by TRANSACTIONS_ACCOUNT_UID, probably during the cleanup phase. While clearing the transactions at the beginning of testAddMultiCurrencyTransaction() might not be the ideal solution, that's the shortest one I could find that consistently fixes this legacy test. I don't want to touch any other passing tests and possibly introduce further bugs in them.

I'm convinced this change fixes Issue https://github.com/GnuCash-Pocket/gnucash-android/issues/26.