### PR TITLE
Fix issue #790 - text margins for RTL text in transaction details screen.

### DIFF
--- a/app/src/main/res/layout/activity_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_transaction_detail.xml
@@ -30,7 +30,7 @@
             android:layout_width="match_parent"
             android:layout_height="128dp"
             android:minHeight="?attr/actionBarSize"
-            android:gravity="bottom"
+            android:gravity="center_vertical"
             android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
 
@@ -43,7 +43,9 @@
                     android:id="@+id/trn_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:text="Transaction description which can be rather long"
+                    android:layout_marginEnd="@dimen/edge_padding"
+                    android:layout_marginRight="@dimen/edge_padding"
+                    tools:text="@tools:sample/lorem/random"
                     android:gravity="bottom"
                     android:maxLines="3"
                     android:paddingBottom="20dp"
@@ -57,6 +59,8 @@
                     android:layout_gravity="bottom"
                     android:layout_marginStart="8dp"
                     android:layout_marginLeft="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
                     android:maxLines="1"
                     android:ellipsize="start"
                     android:textStyle="italic"


### PR DESCRIPTION
No margin for right-aligned title in transaction details screen.