### PR TITLE
fix date format in CSV export

### DIFF
--- a/app/src/main/java/org/gnucash/android/export/csv/CsvTransactionsExporter.java
+++ b/app/src/main/java/org/gnucash/android/export/csv/CsvTransactionsExporter.java
@@ -54,7 +54,7 @@ public class CsvTransactionsExporter extends Exporter {
 
     private char mCsvSeparator;
 
-    private DateFormat dateFormat = new SimpleDateFormat("YYYY-MM-dd", Locale.US);
+    private DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
     /**
      * Construct a new exporter with export parameters


### PR DESCRIPTION
Fix date format (from "week year" to "year") so that last/first days of year don't get a wrong year when exporting (Issue #33)
Based on thatsokay's PR https://github.com/codinguser/gnucash-android/pull/904/commits/fea03d3d6af0c9f1fb3083080388742ae73c38fa. He also removed the trailing delimiter at the end of the heading row, but I'm not good in Java and am not sure if I break sth.