### PR TITLE
Backup book not in main thread. Remove file type extension.

### DIFF
--- a/app/src/main/java/org/gnucash/android/importer/ImportAsyncTask.java
+++ b/app/src/main/java/org/gnucash/android/importer/ImportAsyncTask.java
@@ -32,6 +32,7 @@ import org.gnucash.android.R;
 import org.gnucash.android.db.DatabaseSchema;
 import org.gnucash.android.db.adapter.BooksDbAdapter;
 import org.gnucash.android.ui.util.TaskDelegate;
+import org.gnucash.android.util.BackupManager;
 import org.gnucash.android.util.BookUtils;
 
 import java.io.InputStream;
@@ -43,17 +44,22 @@ import java.io.InputStream;
 public class ImportAsyncTask extends AsyncTask<Uri, Void, Boolean> {
     private final Activity mContext;
     private TaskDelegate mDelegate;
+    private final boolean mBackup;
     private ProgressDialog mProgressDialog;
-
     private String mImportedBookUID;
 
     public ImportAsyncTask(Activity context) {
-        this.mContext = context;
+        this(context, null);
     }
 
     public ImportAsyncTask(Activity context, TaskDelegate delegate) {
+        this(context, delegate, false);
+    }
+
+    public ImportAsyncTask(Activity context, TaskDelegate delegate, boolean backup) {
         this.mContext = context;
         this.mDelegate = delegate;
+        this.mBackup = backup;
     }
 
     @Override
@@ -68,19 +74,21 @@ public class ImportAsyncTask extends AsyncTask<Uri, Void, Boolean> {
         //these methods must be called after progressDialog.show()
         mProgressDialog.setProgressNumberFormat(null);
         mProgressDialog.setProgressPercentFormat(null);
-
-
     }
 
     @Override
     protected Boolean doInBackground(Uri... uris) {
-        try {
-            InputStream accountInputStream = mContext.getContentResolver().openInputStream(uris[0]);
-            mImportedBookUID = GncXmlImporter.parse(accountInputStream);
+        if (mBackup) {
+            BackupManager.backupActiveBook();
+        }
 
+        Uri uri = uris[0];
+        try {
+            InputStream accountInputStream = mContext.getContentResolver().openInputStream(uri);
+            mImportedBookUID = GncXmlImporter.parse(accountInputStream);
         } catch (Exception exception) {
-            Log.e(ImportAsyncTask.class.getName(), "" + exception.getMessage());
-            FirebaseCrashlytics.getInstance().log("Could not open: " + uris[0].toString());
+            Log.e(ImportAsyncTask.class.getName(), exception.getMessage());
+            FirebaseCrashlytics.getInstance().log("Could not open: " + uri.toString());
             FirebaseCrashlytics.getInstance().recordException(exception);
             exception.printStackTrace();
 
@@ -98,13 +106,18 @@ public class ImportAsyncTask extends AsyncTask<Uri, Void, Boolean> {
             return false;
         }
 
-        Cursor cursor = mContext.getContentResolver().query(uris[0], null, null, null, null);
+        Cursor cursor = mContext.getContentResolver().query(uri, null, null, null, null);
         if (cursor != null && cursor.moveToFirst()) {
             int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
             String displayName = cursor.getString(nameIndex);
+            // Remove short file type extension, e.g. ".xml" or ".gnca".
+            int indexFileType = displayName.lastIndexOf('.');
+            if ((indexFileType > 0) && (indexFileType + 5 >= displayName.length())) {
+                displayName = displayName.substring(0, indexFileType);
+            }
             ContentValues contentValues = new ContentValues();
             contentValues.put(DatabaseSchema.BookEntry.COLUMN_DISPLAY_NAME, displayName);
-            contentValues.put(DatabaseSchema.BookEntry.COLUMN_SOURCE_URI, uris[0].toString());
+            contentValues.put(DatabaseSchema.BookEntry.COLUMN_SOURCE_URI, uri.toString());
             BooksDbAdapter.getInstance().updateRecord(mImportedBookUID, contentValues);
 
             cursor.close();

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -509,8 +509,7 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
      * @param onFinishTask Task to be executed when import is complete
      */
     public static void importXmlFileFromIntent(Activity context, Intent data, TaskDelegate onFinishTask) {
-        BackupManager.backupActiveBook();
-        new ImportAsyncTask(context, onFinishTask).execute(data.getData());
+        new ImportAsyncTask(context, onFinishTask, true).execute(data.getData());
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
@@ -312,8 +312,8 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity implements
             case BaseDrawerActivity.REQUEST_OPEN_DOCUMENT: //this uses the Storage Access Framework
                 final int takeFlags = data.getFlags()
                         & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                AccountsActivity.importXmlFileFromIntent(this, data, null);
                 getContentResolver().takePersistableUriPermission(data.getData(), takeFlags);
+                AccountsActivity.importXmlFileFromIntent(this, data, null);
                 break;
             default:
                 super.onActivityResult(requestCode, resultCode, data);


### PR DESCRIPTION
Backup book not in main thread (causes ANR for large books).
Remove file type extension when importing a book file.