### PR TITLE
Backup each book

### DIFF
--- a/app/src/main/java/org/gnucash/android/util/BackupManager.java
+++ b/app/src/main/java/org/gnucash/android/util/BackupManager.java
@@ -64,27 +64,9 @@ public class BackupManager {
     static void backupAllBooks() {
         BooksDbAdapter booksDbAdapter = BooksDbAdapter.getInstance();
         List<String> bookUIDs = booksDbAdapter.getAllBookUIDs();
-        Context context = GnuCashApplication.getAppContext();
 
         for (String bookUID : bookUIDs) {
-            String backupFile = getBookBackupFileUri(bookUID);
-            if (backupFile == null) {
-                backupBook(bookUID);
-                continue;
-            }
-
-            try (BufferedOutputStream bufferedOutputStream =
-                         new BufferedOutputStream(context.getContentResolver().openOutputStream(Uri.parse(backupFile)))) {
-                GZIPOutputStream gzipOutputStream = new GZIPOutputStream(bufferedOutputStream);
-                OutputStreamWriter writer = new OutputStreamWriter(gzipOutputStream);
-                ExportParams params = new ExportParams(ExportFormat.XML);
-                new GncXmlExporter(params).generateExport(writer);
-                writer.close();
-            } catch (IOException ex) {
-                Log.e(LOG_TAG, "Auto backup failed for book " + bookUID);
-                ex.printStackTrace();
-                FirebaseCrashlytics.getInstance().recordException(ex);
-            }
+            backupBook(bookUID);
         }
     }
 
@@ -123,7 +105,7 @@ public class BackupManager {
             new GncXmlExporter(params).generateExport(writer);
             writer.close();
             return true;
-        } catch (IOException | Exporter.ExporterException e) {
+        } catch (IOException | Exporter.ExporterException | NullPointerException e) {
             FirebaseCrashlytics.getInstance().recordException(e);
             Log.e("GncXmlExporter", "Error creating XML  backup", e);
             return false;


### PR DESCRIPTION
There was an issue with nextcloud/ownCloud when backup book:

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.owncloud.android.datamodel.OCFile.existsOnDevice()' on a null object reference
       at android.os.Parcel.createExceptionOrNull(Parcel.java:3017)
       at android.os.Parcel.createException(Parcel.java:2995)
       at android.os.Parcel.readException(Parcel.java:2978)
       at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:190)
       at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:153)
       at android.content.ContentProviderProxy.openAssetFile(ContentProviderNative.java:705)
       at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1862)
       at android.content.ContentResolver.openOutputStream(ContentResolver.java:1564)
       at android.content.ContentResolver.openOutputStream(ContentResolver.java:1539)
       at org.gnucash.android.util.BackupManager.backupAllBooks(BackupManager.java:76)
       at org.gnucash.android.util.BackupJob.onHandleWork(BackupJob.java:46)
       at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:396)
       at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:387)
       at android.os.AsyncTask$3.call(AsyncTask.java:394)
       at java.util.concurrent.FutureTask.run(FutureTask.java:264)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```