### PR TITLE
Progress dialog can cancel.

### DIFF
--- a/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
+++ b/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
@@ -118,6 +118,8 @@ public class ExportAsyncTask extends AsyncTask<ExportParams, Void, Integer> {
         if (mContext instanceof Activity) {
             mProgressDialog = new GnucashProgressDialog((Activity) mContext);
             mProgressDialog.setTitle(R.string.title_progress_exporting_transactions);
+            mProgressDialog.setCancelable(true);
+            mProgressDialog.setOnCancelListener(dialogInterface -> cancel(true));
             mProgressDialog.show();
         }
     }
@@ -209,8 +211,9 @@ public class ExportAsyncTask extends AsyncTask<ExportParams, Void, Integer> {
 
     private void dismissProgressDialog() {
         if (mContext instanceof Activity) {
-            if (mProgressDialog != null && mProgressDialog.isShowing())
+            if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.dismiss();
+            }
             ((Activity) mContext).finish();
         }
     }

--- a/app/src/main/java/org/gnucash/android/importer/ImportAsyncTask.java
+++ b/app/src/main/java/org/gnucash/android/importer/ImportAsyncTask.java
@@ -68,6 +68,8 @@ public class ImportAsyncTask extends AsyncTask<Uri, Void, Boolean> {
         super.onPreExecute();
         mProgressDialog = new GnucashProgressDialog(mContext);
         mProgressDialog.setTitle(R.string.title_progress_importing_accounts);
+        mProgressDialog.setCancelable(true);
+        mProgressDialog.setOnCancelListener(dialogInterface -> cancel(true));
         mProgressDialog.show();
     }
 
@@ -130,8 +132,9 @@ public class ImportAsyncTask extends AsyncTask<Uri, Void, Boolean> {
     @Override
     protected void onPostExecute(Boolean importSuccess) {
         try {
-            if (mProgressDialog != null && mProgressDialog.isShowing())
+            if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.dismiss();
+            }
         } catch (IllegalArgumentException ex) {
             //TODO: This is a hack to catch "View not attached to window" exceptions
             //FIXME by moving the creation and display of the progress dialog to the Fragment

--- a/app/src/main/java/org/gnucash/android/ui/settings/dialog/DoubleConfirmationDialog.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/dialog/DoubleConfirmationDialog.java
@@ -69,8 +69,9 @@ public abstract class DoubleConfirmationDialog extends DialogFragment {
     @Override
     public void onStart() {
         super.onStart();
-        if (getDialog() != null) {
-            ((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+        final AlertDialog dialog = (AlertDialog) getDialog();
+        if (dialog != null) {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
             setUpConfirmCheckBox();
         }
     }
@@ -93,6 +94,6 @@ public abstract class DoubleConfirmationDialog extends DialogFragment {
      * <p>By default it just dismisses the dialog.</p>
      */
     protected void onNegativeButton() {
-        getDialog().dismiss();
+        dismiss();
     }
 }

--- a/app/src/main/java/org/gnucash/android/util/BackupManager.java
+++ b/app/src/main/java/org/gnucash/android/util/BackupManager.java
@@ -195,6 +195,8 @@ public class BackupManager {
                 if (activity != null) {
                     mProgressDialog = new GnucashProgressDialog(activity);
                     mProgressDialog.setTitle(R.string.title_create_backup_pref);
+                    mProgressDialog.setCancelable(true);
+                    mProgressDialog.setOnCancelListener(dialogInterface -> cancel(true));
                     mProgressDialog.show();
                 }
             }
@@ -224,6 +226,8 @@ public class BackupManager {
                 if (activity != null) {
                     mProgressDialog = new GnucashProgressDialog(activity);
                     mProgressDialog.setTitle(R.string.title_create_backup_pref);
+                    mProgressDialog.setCancelable(true);
+                    mProgressDialog.setOnCancelListener(dialogInterface -> cancel(true));
                     mProgressDialog.show();
                 }
             }


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalArgumentException: View=DecorView@d34449b[Exporting transactions] not attached to window manager
       at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:657)
       at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:564)
       at android.view.WindowManagerImpl.removeViewImmediate(WindowManagerImpl.java:208)
       at android.app.Dialog.dismissDialog(Dialog.java:801)
       at android.app.Dialog.dismiss(Dialog.java:783)
       at org.gnucash.android.export.ExportAsyncTask.dismissProgressDialog(ExportAsyncTask.java:205)
       at org.gnucash.android.export.ExportAsyncTask.onPostExecute(ExportAsyncTask.java:186)
       at org.gnucash.android.export.ExportAsyncTask.onPostExecute(ExportAsyncTask.java:89)
       at android.os.AsyncTask.finish(AsyncTask.java:771)
       at android.os.AsyncTask.-$$Nest$mfinish()
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:230)
       at android.os.Looper.loop(Looper.java:319)
       at android.app.ActivityThread.main(ActivityThread.java:8893)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:608)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
```