### PR TITLE
Security exception when backup book

### DIFF
--- a/app/src/androidTest/java/org/gnucash/android/test/ui/AccountsActivityTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/AccountsActivityTest.java
@@ -473,11 +473,11 @@ public class AccountsActivityTest {
     //TODO: test settings activity
     @Test
     public void testIntentAccountCreation() {
-        Intent intent = new Intent(Intent.ACTION_INSERT);
-        intent.putExtra(Intent.EXTRA_TITLE, "Intent Account");
-        intent.putExtra(Intent.EXTRA_UID, "intent-account");
-        intent.putExtra(Account.EXTRA_CURRENCY_CODE, "EUR");
-        intent.setType(Account.MIME_TYPE);
+        Intent intent = new Intent(Intent.ACTION_INSERT)
+            .putExtra(Intent.EXTRA_TITLE, "Intent Account")
+            .putExtra(Intent.EXTRA_UID, "intent-account")
+            .putExtra(Account.EXTRA_CURRENCY_CODE, "EUR")
+            .setType(Account.MIME_TYPE);
 
         new AccountCreator().onReceive(mAccountsActivity, intent);
 

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
@@ -652,14 +652,14 @@ public class TransactionsActivityTest {
     @Test
     public void testLegacyIntentTransactionRecording() {
         int beforeCount = mTransactionsDbAdapter.getTransactionsCount(TRANSACTIONS_ACCOUNT_UID);
-        Intent transactionIntent = new Intent(Intent.ACTION_INSERT);
-        transactionIntent.setType(Transaction.MIME_TYPE);
-        transactionIntent.putExtra(Intent.EXTRA_TITLE, "Power intents");
-        transactionIntent.putExtra(Intent.EXTRA_TEXT, "Intents for sale");
-        transactionIntent.putExtra(Transaction.EXTRA_AMOUNT, new BigDecimal(4.99));
-        transactionIntent.putExtra(Transaction.EXTRA_ACCOUNT_UID, TRANSACTIONS_ACCOUNT_UID);
-        transactionIntent.putExtra(Transaction.EXTRA_TRANSACTION_TYPE, TransactionType.DEBIT.name());
-        transactionIntent.putExtra(Account.EXTRA_CURRENCY_CODE, "USD");
+        Intent transactionIntent = new Intent(Intent.ACTION_INSERT)
+            .setType(Transaction.MIME_TYPE)
+            .putExtra(Intent.EXTRA_TITLE, "Power intents")
+            .putExtra(Intent.EXTRA_TEXT, "Intents for sale")
+            .putExtra(Transaction.EXTRA_AMOUNT, new BigDecimal(4.99))
+            .putExtra(Transaction.EXTRA_ACCOUNT_UID, TRANSACTIONS_ACCOUNT_UID)
+            .putExtra(Transaction.EXTRA_TRANSACTION_TYPE, TransactionType.DEBIT.name())
+            .putExtra(Account.EXTRA_CURRENCY_CODE, "USD");
 
         new TransactionRecorder().onReceive(mTransactionsActivity, transactionIntent);
 

--- a/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
@@ -743,8 +743,8 @@ public class MigrationHelper {
                 db.insert(ScheduledActionEntry.TABLE_NAME, null, contentValues);
 
                 //build intent for recurring transactions in the database
-                Intent intent = new Intent(Intent.ACTION_INSERT);
-                intent.setType(Transaction.MIME_TYPE);
+                Intent intent = new Intent(Intent.ACTION_INSERT)
+                    .setType(Transaction.MIME_TYPE);
 
                 //cancel existing pending intent
                 Context context = GnuCashApplication.getAppContext();

--- a/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
+++ b/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
@@ -480,15 +480,13 @@ public class ExportAsyncTask extends AsyncTask<ExportParams, Void, Integer> {
      * @param paths list of full paths of the files to send to the activity.
      */
     private void shareFiles(ExportParams exportParams, List<String> paths) {
-        Intent shareIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);
-        shareIntent.setType("text/xml");
-
         ArrayList<Uri> exportFiles = convertFilePathsToUris(paths);
-        shareIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, exportFiles);
-        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-        shareIntent.putExtra(Intent.EXTRA_SUBJECT, mContext.getString(R.string.title_export_email,
-            exportParams.getExportFormat().name()));
+        Intent shareIntent = new Intent(Intent.ACTION_SEND_MULTIPLE)
+            .setType("text/xml")
+            .putParcelableArrayListExtra(Intent.EXTRA_STREAM, exportFiles)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            .putExtra(Intent.EXTRA_SUBJECT, mContext.getString(R.string.title_export_email,
+                exportParams.getExportFormat().name()));
 
         String defaultEmail = PreferenceManager.getDefaultSharedPreferences(mContext)
                 .getString(mContext.getString(R.string.key_default_export_email), null);

--- a/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
+++ b/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
@@ -134,7 +134,7 @@ public class ExportAsyncTask extends AsyncTask<ExportParams, Void, Integer> {
 
         try {
             exportedFiles = exporter.generateExport();
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
             Timber.e(e, "Error exporting: %s", e.getMessage());
             if (mContext instanceof Activity) {
                 ((Activity) mContext).runOnUiThread(new Runnable() {
@@ -142,7 +142,7 @@ public class ExportAsyncTask extends AsyncTask<ExportParams, Void, Integer> {
                     public void run() {
                         Toast.makeText(mContext,
                                 mContext.getString(R.string.toast_export_error, exportParams.getExportFormat().name())
-                                        + "\n" + e.getMessage(),
+                                        + "\n" + e.getLocalizedMessage(),
                                 Toast.LENGTH_SHORT).show();
                     }
                 });

--- a/app/src/main/java/org/gnucash/android/importer/ImportAsyncTask.java
+++ b/app/src/main/java/org/gnucash/android/importer/ImportAsyncTask.java
@@ -82,14 +82,14 @@ public class ImportAsyncTask extends AsyncTask<Uri, Void, Boolean> {
         try {
             InputStream accountInputStream = mContext.getContentResolver().openInputStream(uri);
             mImportedBookUID = GncXmlImporter.parse(accountInputStream);
-        } catch (final Exception exception) {
-            Timber.e(exception, "Could not open: %s", uri);
+        } catch (final Throwable e) {
+            Timber.e(e, "Error importing: %s", uri);
 
             mContext.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
                     Toast.makeText(mContext,
-                            mContext.getString(R.string.toast_error_importing_accounts) + "\n" + exception.getLocalizedMessage(),
+                            mContext.getString(R.string.toast_error_importing_accounts) + "\n" + e.getLocalizedMessage(),
                             Toast.LENGTH_LONG).show();
                 }
             });

--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsActivity.java
@@ -458,9 +458,9 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
      * @see #importXmlFileFromIntent(Activity, Intent, TaskDelegate)
      */
     public static void startXmlFileChooser(Activity activity) {
-        Intent pickIntent = new Intent(Intent.ACTION_GET_CONTENT);
-        pickIntent.addCategory(Intent.CATEGORY_OPENABLE);
-        pickIntent.setType("*/*");
+        Intent pickIntent = new Intent(Intent.ACTION_GET_CONTENT)
+            .addCategory(Intent.CATEGORY_OPENABLE)
+            .setType("*/*");
         Intent chooser = Intent.createChooser(pickIntent, "Select GnuCash account file"); //todo internationalize string
 
         try {
@@ -479,9 +479,9 @@ public class AccountsActivity extends BaseDrawerActivity implements OnAccountCli
      * @see #startXmlFileChooser(Activity)
      */
     public static void startXmlFileChooser(Fragment fragment) {
-        Intent pickIntent = new Intent(Intent.ACTION_GET_CONTENT);
-        pickIntent.addCategory(Intent.CATEGORY_OPENABLE);
-        pickIntent.setType("*/*");
+        Intent pickIntent = new Intent(Intent.ACTION_GET_CONTENT)
+            .addCategory(Intent.CATEGORY_OPENABLE)
+            .setType("*/*");
         Intent chooser = Intent.createChooser(pickIntent, "Select GnuCash account file"); //todo internationalize string
 
         try {

--- a/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/BaseDrawerActivity.java
@@ -244,12 +244,12 @@ public abstract class BaseDrawerActivity extends PasscodeLockActivity {
     protected void onDrawerMenuItemClicked(int itemId) {
         switch (itemId) {
             case R.id.nav_item_open: { //Open... files
-                //use the storage access framework
-                Intent openDocument = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                openDocument.addCategory(Intent.CATEGORY_OPENABLE);
-                openDocument.setType("text/*|application/*");
                 String[] mimeTypes = {"text/*", "application/*"};
-                openDocument.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+                //use the storage access framework
+                Intent openDocument = new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                    .addCategory(Intent.CATEGORY_OPENABLE)
+                    .setType("text/*|application/*")
+                    .putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
                 startActivityForResult(openDocument, REQUEST_OPEN_DOCUMENT);
             }
             break;

--- a/app/src/main/java/org/gnucash/android/ui/export/ExportFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/export/ExportFormFragment.java
@@ -556,11 +556,13 @@ public class ExportFormFragment extends Fragment implements
      * Open a chooser for user to pick a file to export to
      */
     private void selectExportFile() {
-        Intent createIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-        createIntent.setType("*/*").addCategory(Intent.CATEGORY_OPENABLE);
         String bookName = BooksDbAdapter.getInstance().getActiveBookDisplayName();
         String filename = Exporter.buildExportFilename(mExportParams.getExportFormat(), bookName);
-        createIntent.putExtra(Intent.EXTRA_TITLE, filename);
+
+        Intent createIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT)
+            .setType("*/*")
+            .addCategory(Intent.CATEGORY_OPENABLE)
+            .putExtra(Intent.EXTRA_TITLE, filename);
         startActivityForResult(createIntent, REQUEST_EXPORT_FILE);
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/settings/AccountPreferencesFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/AccountPreferencesFragment.java
@@ -164,14 +164,13 @@ public class AccountPreferencesFragment extends PreferenceFragmentCompat impleme
      * Open a chooser for user to pick a file to export to
      */
     private void selectExportFile() {
-        Intent createIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-        createIntent.setType("*/*").addCategory(Intent.CATEGORY_OPENABLE);
         String bookName = BooksDbAdapter.getInstance().getActiveBookDisplayName();
-
         String filename = Exporter.buildExportFilename(ExportFormat.CSVA, bookName);
-        createIntent.setType("application/text");
 
-        createIntent.putExtra(Intent.EXTRA_TITLE, filename);
+        Intent createIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT)
+            .setType("*/*")
+            .addCategory(Intent.CATEGORY_OPENABLE)
+            .putExtra(Intent.EXTRA_TITLE, filename);
         startActivityForResult(createIntent, REQUEST_EXPORT_FILE);
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/settings/BackupPreferenceFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/BackupPreferenceFragment.java
@@ -187,11 +187,13 @@ public class BackupPreferenceFragment extends PreferenceFragmentCompat implement
         }
 
         if (key.equals(getString(R.string.key_backup_location))) {
-            Intent createIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
-            createIntent.setType("*/*");
-            createIntent.addCategory(Intent.CATEGORY_OPENABLE);
             String bookName = BooksDbAdapter.getInstance().getActiveBookDisplayName();
-            createIntent.putExtra(Intent.EXTRA_TITLE, Exporter.sanitizeFilename(bookName) + "_" + getString(R.string.label_backup_filename));
+            String fileName = Exporter.sanitizeFilename(bookName) + "_" + getString(R.string.label_backup_filename);
+
+            Intent createIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT)
+                .setType(BackupManager.MIME_TYPE)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .putExtra(Intent.EXTRA_TITLE, fileName);
             startActivityForResult(createIntent, REQUEST_BACKUP_FILE);
         }
 

--- a/app/src/main/java/org/gnucash/android/ui/settings/BackupPreferenceFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/BackupPreferenceFragment.java
@@ -17,6 +17,7 @@
 package org.gnucash.android.ui.settings;
 
 import static org.gnucash.android.app.IntentExtKt.takePersistableUriPermission;
+import static org.gnucash.android.util.ContentExtKt.getDocumentName;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -105,9 +106,6 @@ public class BackupPreferenceFragment extends PreferenceFragmentCompat implement
      */
     public static GoogleApiClient mGoogleApiClient;
 
-    private static final String[] PROJECTION_NAME = {DocumentsContract.Document.COLUMN_DISPLAY_NAME};
-    private static final int INDEX_NAME = 0;
-
     @Override
     public void onCreatePreferences(Bundle bundle, String s) {
         addPreferencesFromResource(R.xml.fragment_backup_preferences);
@@ -166,7 +164,7 @@ public class BackupPreferenceFragment extends PreferenceFragmentCompat implement
         pref.setOnPreferenceClickListener(this);
         Uri defaultBackupLocation = BackupManager.getBookBackupFileUri(BooksDbAdapter.getInstance().getActiveBookUID());
         if (defaultBackupLocation != null) {
-            pref.setSummary(getName(defaultBackupLocation));
+            pref.setSummary(getDocumentName(defaultBackupLocation, pref.getContext()));
         }
 
         pref = findPreference(getString(R.string.key_dropbox_sync));
@@ -486,22 +484,9 @@ public class BackupPreferenceFragment extends PreferenceFragmentCompat implement
                             .apply();
 
                     Preference pref = findPreference(getString(R.string.key_backup_location));
-                    pref.setSummary(getName(backupFileUri));
+                    pref.setSummary(getDocumentName(backupFileUri, pref.getContext()));
                 }
                 break;
         }
-    }
-
-    private String getName(Uri uri) {
-        String name = uri.getAuthority();
-        ContentResolver resolver = requireContext().getContentResolver();
-        Cursor cursor = resolver.query(uri, PROJECTION_NAME, null, null, null);
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                name = cursor.getString(INDEX_NAME);
-            }
-            cursor.close();
-        }
-        return name;
     }
 }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/ScheduledActionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/ScheduledActionsListFragment.java
@@ -16,6 +16,8 @@
 
 package org.gnucash.android.ui.transaction;
 
+import static org.gnucash.android.util.ContentExtKt.getDocumentName;
+
 import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -574,7 +576,7 @@ public class ScheduledActionsListFragment extends ListFragment implements
             ExportParams params = ExportParams.parseCsv(scheduledAction.getTag());
             String exportDestination = params.getExportTarget().getDescription();
             if (params.getExportTarget() == ExportParams.ExportTarget.URI) {
-                exportDestination = exportDestination + " (" + getName(params.getExportLocation()) + ")";
+                exportDestination = exportDestination + " (" + getDocumentName(params.getExportLocation(), context) + ")";
             }
             String description = context.getString(
                 R.string.schedule_export_desription,
@@ -645,22 +647,6 @@ public class ScheduledActionsListFragment extends ListFragment implements
             registerContentObserver(c);
             return c;
         }
-    }
-
-    private static final String[] PROJECTION_NAME = {DocumentsContract.Document.COLUMN_DISPLAY_NAME};
-    private static final int INDEX_NAME = 0;
-
-    private String getName(Uri uri) {
-        String name = uri.getAuthority();
-        ContentResolver resolver = requireContext().getContentResolver();
-        Cursor cursor = resolver.query(uri, PROJECTION_NAME, null, null, null);
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                name = cursor.getString(INDEX_NAME);
-            }
-            cursor.close();
-        }
-        return name;
     }
 }
 

--- a/app/src/main/java/org/gnucash/android/util/BackupManager.java
+++ b/app/src/main/java/org/gnucash/android/util/BackupManager.java
@@ -149,7 +149,7 @@ public class BackupManager {
             writer.close();
             return true;
         } catch (Throwable e) {
-            Timber.e(e, "Error creating XML  backup");
+            Timber.e(e, "Error creating XML backup");
             return false;
         }
     }

--- a/app/src/main/java/org/gnucash/android/util/BackupManager.java
+++ b/app/src/main/java/org/gnucash/android/util/BackupManager.java
@@ -63,6 +63,7 @@ import timber.log.Timber;
 public class BackupManager {
 
     public static final String KEY_BACKUP_FILE = "book_backup_file_key";
+    public static final String MIME_TYPE = "application/gzip";
 
     /**
      * Perform an automatic backup of all books in the database.

--- a/app/src/main/java/org/gnucash/android/util/ContentExt.kt
+++ b/app/src/main/java/org/gnucash/android/util/ContentExt.kt
@@ -1,0 +1,23 @@
+package org.gnucash.android.util
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import org.gnucash.android.ui.transaction.ScheduledActionsListFragment
+
+private val PROJECTION_DOCUMENT_NAME = arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+private const val INDEX_DOCUMENT_NAME = 0
+
+fun Uri.getDocumentName(context: Context): String {
+    var name: String = this.authority ?: this.host ?: ""
+    val resolver: ContentResolver = context.getContentResolver()
+    val cursor = resolver.query(this, PROJECTION_DOCUMENT_NAME, null, null, null)
+    if (cursor != null) {
+        if (cursor.moveToFirst()) {
+            name = cursor.getString(INDEX_DOCUMENT_NAME)
+        }
+        cursor.close()
+    }
+    return name
+}

--- a/app/src/main/kotlin/org/gnucash/android/model/Recurrence.kt
+++ b/app/src/main/kotlin/org/gnucash/android/model/Recurrence.kt
@@ -329,7 +329,7 @@ class Recurrence(periodType: PeriodType) : BaseModel() {
      * @return String describing the period type
      */
     private val frequencyRepeatString: String
-        private get() {
+        get() {
             val res = GnuCashApplication.getAppContext().resources
             return when (periodType) {
                 PeriodType.HOUR -> res.getQuantityString(
@@ -374,7 +374,6 @@ class Recurrence(periodType: PeriodType) : BaseModel() {
          */
         @JvmStatic
         fun fromLegacyPeriod(period: Long): Recurrence {
-
             var result = (period / RecurrenceParser.YEAR_MILLIS).toInt()
             if (result > 0) {
                 val recurrence = Recurrence(PeriodType.YEAR)

--- a/app/src/main/kotlin/org/gnucash/android/model/ScheduledAction.kt
+++ b/app/src/main/kotlin/org/gnucash/android/model/ScheduledAction.kt
@@ -15,6 +15,7 @@
  */
 package org.gnucash.android.model
 
+import androidx.annotation.StringRes
 import org.gnucash.android.R
 import org.gnucash.android.app.GnuCashApplication
 import org.joda.time.LocalDateTime
@@ -57,8 +58,9 @@ class ScheduledAction    //all actions are enabled by default
     /**
      * Types of events which can be scheduled
      */
-    enum class ActionType {
-        TRANSACTION, BACKUP
+    enum class ActionType(@JvmField @StringRes val labelId: Int) {
+        TRANSACTION(R.string.action_transaction),
+        BACKUP(R.string.action_backup)
     }
 
     /**

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -448,8 +448,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -480,8 +480,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -446,8 +446,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -451,8 +451,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -446,8 +446,6 @@ No user-identifiable information will be collected as part of this process!</str
     <string name="btn_restore">Wiederherstellen</string>
     <string name="title_no_backups_found">Keine Sicherungen gefunden</string>
     <string name="msg_no_backups_to_restore_from">Es sind keine Sicherungsdateien vorhanden, die wiederhergestellt werden könnten</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Wähle den Zielort, wenn der Export abgeschlossen wurde</string>
     <string name="label_dropbox_export_destination">Exportiere in Dropbox-Ordner: \'/Apps/GnuCash Android/\'</string>
     <string name="title_section_preferences">Voreinstellungen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -459,8 +459,6 @@ No user-identifiable information will be collected as part of this process!
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -448,8 +448,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -174,11 +174,6 @@
         <item>MUTUAL FUND</item>
         <item>TRADING</item>
     </string-array>
-    <string-array name="export_formats">
-        <item>QIF</item>
-        <item>OFX</item>
-        <item>XML</item>
-    </string-array>
     <!-- Default title for color picker dialog [CHAR LIMIT=30] -->
     <string name="color_picker_default_title">Select a Color</string>
     <!-- Content description for a color square. -->

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -448,8 +448,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-en-rZA/strings.xml
+++ b/app/src/main/res/values-en-rZA/strings.xml
@@ -448,8 +448,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-en-rZA/strings.xml
+++ b/app/src/main/res/values-en-rZA/strings.xml
@@ -174,11 +174,6 @@
         <item>MUTUAL FUND</item>
         <item>TRADING</item>
     </string-array>
-    <string-array name="export_formats">
-        <item>QIF</item>
-        <item>OFX</item>
-        <item>XML</item>
-    </string-array>
     <!-- Default title for color picker dialog [CHAR LIMIT=30] -->
     <string name="color_picker_default_title">Select a Color</string>
     <!-- Content description for a color square. -->

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -442,8 +442,6 @@ Este proceso solo recoge información que no permite identificar al usuario</str
     <string name="btn_restore">Restaurar</string>
     <string name="title_no_backups_found">No se han encontrado copias de seguridad</string>
     <string name="msg_no_backups_to_restore_from">No hay archivos de copia de seguridad desde donde restaurar</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Seleccione el destino después de la exportación</string>
     <string name="label_dropbox_export_destination">Exportar a carpeta en Dropbox \' / Apps/GnuCash Android /\'</string>
     <string name="title_section_preferences">Preferencias</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -442,8 +442,6 @@ Este proceso solo recoge información que no permite identificar al usuario</str
     <string name="btn_restore">Restaurar</string>
     <string name="title_no_backups_found">No se han encontrado copias de seguridad</string>
     <string name="msg_no_backups_to_restore_from">No hay archivos de copia de seguridad desde donde restaurar</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Seleccione el destino después de la exportación</string>
     <string name="label_dropbox_export_destination">Exportar a carpeta en Dropbox \' / Apps/GnuCash Android /\'</string>
     <string name="title_section_preferences">Preferencias</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -448,8 +448,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -448,8 +448,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -440,8 +440,6 @@
     <string name="btn_restore">Restaurer</string>
     <string name="title_no_backups_found">Aucune sauvegarde trouvée</string>
     <string name="msg_no_backups_to_restore_from">Il n\'y a pas de fichiers de sauvegarde existants pour restaurer</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Sélectionnez la destination une fois l\'exportation terminée</string>
     <string name="label_dropbox_export_destination">Exporter dans le dossier \'/Apps/GnuCash Android/\' sur Dropbox</string>
     <string name="title_section_preferences">Préférences</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -182,7 +182,7 @@
     <string name="title_all_accounts">Tous</string>
     <string name="summary_create_default_accounts">Crée une structure de compte GnuCash par défaut couramment utilisé</string>
     <string name="title_create_default_accounts">Crée comptes par défaut</string>
-    <string name="msg_confirm_create_default_accounts_setting">Un nouveau livre sera ouvert avec les comptes courants par défaut\n\n Vos comptes et opérations actuels ne seront pas modifiés !</string>
+    <string name="msg_confirm_create_default_accounts_setting">Un nouveau livre sera ouvert avec les comptes courants par défaut\n\n Vos comptes et opérations actuels ne seront pas modifiés!</string>
     <string name="title_scheduled_transactions">Transactions planifiées</string>
     <string name="title_select_export_destination">Selectionnez une destination pour l\'export</string>
     <string name="hint_split_memo">Memo</string>
@@ -264,7 +264,7 @@
     <string name="owncloud_server">https://</string>
     <string name="owncloud_server_invalid">Serveur OC inaccessible</string>
     <string name="owncloud_user_invalid">Nom d’utilisateur/mot de passe OC non valide</string>
-    <string name="owncloud_dir_invalid">Caractères non valides : \\ &lt; &gt; : \&quot; | * ? </string>
+    <string name="owncloud_dir_invalid">Caractères non valides: \\ &lt; &gt; : \&quot; | * ? </string>
     <string name="owncloud_server_ok">Serveur OC OK</string>
     <string name="owncloud_user_ok">Nom d’utilisateur/mot de passe OC OK</string>
     <string name="owncloud_dir_ok">Nom Répertoire OK</string>
@@ -352,7 +352,7 @@
     <string name="title_translate_gnucash">Traduire GnuCash</string>
     <string name="summary_google_plus">Partager des idées, discuter des changements ou signaler des problèmes</string>
     <string name="summary_translate_gnucash">Traduire ou relire sur CrowdIn</string>
-    <string name="toast_no_compatible_apps_to_receive_export">Aucune application compatible pour recevoir les transactions exportées !</string>
+    <string name="toast_no_compatible_apps_to_receive_export">Aucune application compatible pour recevoir les transactions exportées !</string>
     <string name="menu_move_transaction">Déplacer&#8230;</string>
     <string name="menu_duplicate_transaction">Dupliquer</string>
     <string name="title_cash_flow_report">Flux de trésorerie</string>
@@ -396,17 +396,17 @@
     <string name="menu_manage_books">Gérer les livres&#8230;</string>
     <string name="select_chart_to_view_details">Sélectionnez une partie du graphique pour afficher les détails</string>
     <string name="title_confirm_delete_book">Confirmer la suppression du livre</string>
-    <string name="msg_all_book_data_will_be_deleted">Tous les comptes et transactions dans ce livre seront supprimées !</string>
+    <string name="msg_all_book_data_will_be_deleted">Tous les comptes et transactions dans ce livre seront supprimées !</string>
     <string name="btn_delete_book">Supprimer le livre</string>
-    <string name="label_last_export_time">Dernières exportations :</string>
+    <string name="label_last_export_time">Dernières exportations:</string>
     <string name="menu_title_enable_sync">Activer la synchronisation</string>
     <string name="menu_title_new_book">Nouveau livre</string>
     <string name="toast_transaction_has_no_splits_and_cannot_open">La transaction sélectionnée n’a aucun mouvement et ne peut pas être ouvert</string>
     <string name="label_split_count">%1$d mouvements</string>
     <string name="label_inside_account_with_name">dans %1$s</string>
     <plurals name="book_account_stats">
-        <item quantity="one">%d compte</item>
-        <item quantity="other">%d comptes</item>
+        <item quantity="one">%d compte</item>
+        <item quantity="other">%d comptes</item>
     </plurals>
     <plurals name="book_transaction_stats">
         <item quantity="one">%d transaction</item>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -450,8 +450,6 @@ No user-identifiable information will be collected as part of this process!
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -208,13 +208,10 @@
     <string name="export_warning_ofx">OFX tidak mendukung transaksi double-entry</string>
     <string name="export_warning_qif">Menghasilkan file QIF terpisah per mata uang</string>
     <string name="label_imbalance">Tidak seimbang:</string>
-    <string name="btn_add_split">Tambahkan split
- </string>
+    <string name="btn_add_split">Tambahkan split</string>
     <string name="menu_title_favorite">Favorit</string>
-    <string name="drawer_open">Laci navigasi dibuka
- </string>
-    <string name="drawer_close">Laci navigasi tertutup
- </string>
+    <string name="drawer_open">Laci navigasi dibuka</string>
+    <string name="drawer_close">Laci navigasi tertutup</string>
     <string name="title_reports">Laporan</string>
     <string name="title_pie_chart">Bagan Pai</string>
     <string name="title_line_chart">Bagan Garis</string>
@@ -249,8 +246,7 @@
     <string name="title_backup_prefs">Pengaturan Cadangan</string>
     <string name="title_create_backup_pref">Membuat Cadangan</string>
     <string name="summary_create_backup_pref">Buat cadangan dari pembukuan yang aktif</string>
-    <string name="summary_restore_backup_pref">Pulihkan cadangan terbaru buku aktif
- </string>
+    <string name="summary_restore_backup_pref">Pulihkan cadangan terbaru buku aktif</string>
     <string name="toast_backup_successful">Pencadangan berhasil</string>
     <string name="toast_backup_failed">Pencadangan gagal</string>
     <string name="export_warning_xml">Ekspor seluruh akun dan transaksi</string>
@@ -266,12 +262,10 @@
     <string name="owncloud_pref">owncloud</string>
     <string name="owncloud_server">https://</string>
     <string name="owncloud_server_invalid">Server OC tidak ditemukan</string>
-    <string name="owncloud_user_invalid">Username / kata kunci OC tidak valid
- </string>
+    <string name="owncloud_user_invalid">Username / kata kunci OC tidak valid</string>
     <string name="owncloud_dir_invalid">Karakter tidak valid: \\ &lt; &gt; : \&quot; | * ? </string>
     <string name="owncloud_server_ok">Server OC OK</string>
-    <string name="owncloud_user_ok">OC username / password OK
- </string>
+    <string name="owncloud_user_ok">OC username / password OK</string>
     <string name="owncloud_dir_ok">Nama Dir OK</string>
     <plurals name="label_every_x_hours">
         <item quantity="other">Per jam</item>
@@ -319,10 +313,8 @@
     <string name="title_setup_gnucash">Pengaturan GnuCash</string>
     <string name="wizard_title_welcome_to_gnucash">Selamat datang di GnuCash</string>
     <string name="msg_wizard_welcome_page">Sebelum Anda menyelam, \nlmari kita siapkan beberapa hal yang pertama \n\n Untuk melanjutkan, tekan Next</string>
-    <string name="title_split_editor">Editor split
- </string>
-    <string name="toast_error_check_split_amounts">Periksa apakah semua split memiliki jumlah yang valid sebelum menyimpannya!
- !</string>
+    <string name="title_split_editor">Editor split</string>
+    <string name="toast_error_check_split_amounts">Periksa apakah semua split memiliki jumlah yang valid sebelum menyimpannya!</string>
     <string name="label_error_invalid_expression">Ekspresi yang tidak valid!</string>
     <string name="toast_scheduled_recurring_transaction">Transaksi berulang yang dijadwalkan</string>
     <string name="title_transfer_funds">Transfer Dana</string>
@@ -331,18 +323,12 @@
     <string name="label_report_period">Periode:</string>
     <string name="label_convert_from">Dari:</string>
     <string name="label_convert_to">Ke:</string>
-    <string name="msg_provide_exchange_rate">Berikan nilai tukar atau nilai tukar yang dikonversi untuk mentransfer dana
- </string>
-    <string name="hint_exchange_rate">Kurs
- </string>
-    <string name="btn_fetch_quote">Ambil kutipan
- </string>
-    <string name="hint_converted_amount">Jumlah yang Dikonversi
- </string>
-    <string name="title_report_sheet">Lembar
- </string>
-    <string name="label_last_3_months_expenses">Biaya untuk 3 bulan terakhir
- </string>
+    <string name="msg_provide_exchange_rate">Berikan nilai tukar atau nilai tukar yang dikonversi untuk mentransfer dana</string>
+    <string name="hint_exchange_rate">Kurs</string>
+    <string name="btn_fetch_quote">Ambil kutipan</string>
+    <string name="hint_converted_amount">Jumlah yang Dikonversi</string>
+    <string name="title_report_sheet">Lembar</string>
+    <string name="label_last_3_months_expenses">Biaya untuk 3 bulan terakhir</string>
     <string name="label_total_assets">Total aset</string>
     <string name="label_total_liabilities">Jumlah kewajiban</string>
     <string name="label_net_worth">Kekayaan Bersih</string>
@@ -354,8 +340,7 @@
     <string name="menu_group_by_month">Bulan</string>
     <string name="menu_group_by_quarter">Kuartal</string>
     <string name="menu_group_by_year">Tahun</string>
-    <string name="title_balance_sheet_report">Neraca keuangan
- </string>
+    <string name="title_balance_sheet_report">Neraca keuangan</string>
     <string name="label_balance_sheet_total">Jumlah:</string>
     <string name="title_google_plus_community">Komunitas Google+</string>
     <string name="title_translate_gnucash">Menerjemahkan GnuCash</string>
@@ -441,21 +426,13 @@
     <string name="btn_rename">Ubah Nama</string>
     <string name="menu_rename">Ubah Nama</string>
     <string name="title_select_backup_file">Pilih file backup</string>
-    <string name="summary_select_backup_file">Pilih file untuk backup otomatis
- </string>
+    <string name="summary_select_backup_file">Pilih file untuk backup otomatis</string>
     <string name="title_confirm_restore_backup">Yakin memulihkan dari backup</string>
-    <string name="msg_confirm_restore_backup_into_new_book">Sebuah buku baru akan dibuka dengan isi backup ini. Apakah Anda ingin melanjutkan?
- ?</string>
+    <string name="msg_confirm_restore_backup_into_new_book">Sebuah buku baru akan dibuka dengan isi backup ini. Apakah Anda ingin melanjutkan?</string>
     <string name="btn_restore">Mengembalikan</string>
     <string name="title_no_backups_found">Backup tidak ditemukan</string>
-    <string name="msg_no_backups_to_restore_from">Tidak ada file cadangan yang ada untuk dipulihkan
- </string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca
- </string>
-    <string name="label_select_destination_after_export">Pilih tujuan setelah ekspor selesai
- </string>
-    <string name="label_dropbox_export_destination">Ekspor ke folder \'/ Apps / GnuCash Android /\' di Dropbox
- </string>
+    <string name="msg_no_backups_to_restore_from">Tidak ada file cadangan yang ada untuk dipulihkan</string>
+    <string name="label_select_destination_after_export">Pilih tujuan setelah ekspor selesai</string>
+    <string name="label_dropbox_export_destination">Ekspor ke folder \'/ Apps / GnuCash Android /\' di Dropbox</string>
     <string name="title_section_preferences">Preferensi</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -445,8 +445,6 @@
     <string name="btn_restore">Ripristina</string>
     <string name="title_no_backups_found">Nessun backup trovato</string>
     <string name="msg_no_backups_to_restore_from">Non ci sono file di backup da cui effettuare un ripristino</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Seleziona la destinazione al termine dell\'esportazione</string>
     <string name="label_dropbox_export_destination">Esporta su Dropbox nella cartella \'/Apps/GnuCash Android/\'</string>
     <string name="title_section_preferences">Preferenze</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -464,8 +464,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -434,8 +434,6 @@
     <string name="btn_restore">復元</string>
     <string name="title_no_backups_found">バックアップが見つかりません</string>
     <string name="msg_no_backups_to_restore_from">復元する既存のバックアップファイルはありません</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">エクスポートが完了した後、移動先を選択します</string>
     <string name="label_dropbox_export_destination">Dropbox の \'/Apps/GnuCash Android/\' フォルダーにエクスポート</string>
     <string name="title_section_preferences">環境設定</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -436,8 +436,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -456,8 +456,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -438,8 +438,6 @@
     <string name="btn_restore">Gjenopprett</string>
     <string name="title_no_backups_found">Finner ingen sikkerhetskopier</string>
     <string name="msg_no_backups_to_restore_from">Finner ingen sikkerhetskopier å gjenopprette fra</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Innstillinger</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -449,8 +449,6 @@ No user-identifiable information will be collected as part of this process!
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -443,8 +443,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -453,8 +453,6 @@ Konto docelowe używa innej waluty niż konto wyjściowe</string>
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -444,8 +444,6 @@ Neste processo não serão recolhidas informações do utilizador!</string>
     <string name="btn_restore">Restaurar</string>
     <string name="title_no_backups_found">Nenhum backup encontrado</string>
     <string name="msg_no_backups_to_restore_from">Não existem arquivos de backup disponíveis para restaurar</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Selecione o destino após finalizar a exportação</string>
     <string name="label_dropbox_export_destination">Exportar para pasta \'/Apps/GnuCash Android/\' no Dropbox</string>
     <string name="title_section_preferences">Preferências</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -444,8 +444,6 @@ Neste processo não serão recolhidas informações do utilizador!</string>
     <string name="btn_restore">Restaurar</string>
     <string name="title_no_backups_found">Não foram encontradas cópias de segurança</string>
     <string name="msg_no_backups_to_restore_from">Não existem cópias de segurança para restaurar</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Escolha o destino após a exportação estar completa</string>
     <string name="label_dropbox_export_destination">Exportar para a pasta \'/Apps/GnuCash Android/\' na Dropbox</string>
     <string name="title_section_preferences">Preferências</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -456,8 +456,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -460,8 +460,6 @@
     <string name="btn_restore">Восстановить</string>
     <string name="title_no_backups_found">Резервные копии не найдены</string>
     <string name="msg_no_backups_to_restore_from">Нет существующих файлов резервных копий для восстановления</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Выберите пункт назначения после завершения экспорта</string>
     <string name="label_dropbox_export_destination">Экспорт в \' / Apps/GnuCash Android /\' папку на Dropbox</string>
     <string name="title_section_preferences">Настройки</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -456,8 +456,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -438,8 +438,6 @@
     <string name="btn_restore">Återställ</string>
     <string name="title_no_backups_found">Inga säkerhetskopior hittade</string>
     <string name="msg_no_backups_to_restore_from">Det finns inga befintliga säkerhetskopieringsfiler att återställa från</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Välj destination efter att exportering är klar</string>
     <string name="label_dropbox_export_destination">Exportera till \'/Apps/GnuCash Android/\' mapp på Dropbox</string>
     <string name="title_section_preferences">Inställningar</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -448,8 +448,6 @@
     <string name="btn_restore">Geri Yükle</string>
     <string name="title_no_backups_found">Yedek bulunamadı</string>
     <string name="msg_no_backups_to_restore_from">Geri yükleme için yedek dosyası bulunamadı</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_yedek.gnca</string>
     <string name="label_select_destination_after_export">Dışa aktarma tamamlandığında hedef seçin</string>
     <string name="label_dropbox_export_destination">Dropbox\'ta \'/Apps/GnuCash Android/\' dizinine dışa aktar</string>
     <string name="title_section_preferences">Tercihler</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -452,8 +452,6 @@
     <string name="btn_restore">Відновити</string>
     <string name="title_no_backups_found">Резервних копій не знайдено</string>
     <string name="msg_no_backups_to_restore_from">Немає резервних копій для відновлення</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Обрати місце після завершення експорту</string>
     <string name="label_dropbox_export_destination">Експортувати до папки /Apps/GnuCash Android/ у Dropbox</string>
     <string name="title_section_preferences">Параметри</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -440,8 +440,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -436,8 +436,6 @@
     <string name="btn_restore">还原</string>
     <string name="title_no_backups_found">没有发现备份</string>
     <string name="msg_no_backups_to_restore_from">没有找到备份文件</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">选择导出位置</string>
     <string name="label_dropbox_export_destination">导出到Dropbox的 \'/Apps/GnuCash Android/\' 文件夹</string>
     <string name="title_section_preferences">首选项</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -439,7 +439,7 @@ No user-identifiable information will be collected as part of this process!
     <string name="title_no_backups_found">沒有找到備份</string>
     <string name="msg_no_backups_to_restore_from">沒有能恢復的備份</string>
     <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_備份.gnca</string>
+    <string name="label_backup_filename">gnucash_pocket_備份.gnca</string>
     <string name="label_select_destination_after_export">匯出後再選擇目的地</string>
     <string name="label_dropbox_export_destination">匯出到 Dropbox 上的 \'/Apps/GnuCash Android/\' 資料夾</string>
     <string name="title_section_preferences">偏好設定</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -31,11 +31,12 @@
     <string name="key_google_drive_app_folder_id" translatable="false">google_drive_app_folder</string>
     <string name="key_enable_crashlytics" translatable="false">enable_crashlytics</string>
     <string name="key_use_account_color" translatable="false">use_account_color</string>
-    <string name="key_last_export_destination">last_export_destination</string>
-    <string name="key_use_compact_list">use_compact_list</string>
-    <string name="key_prefs_header_general">prefs_header_general</string>
-    <string name="key_dropbox_access_token">dropbox_access_token</string>
-    <string name="key_backup_location">backup_location</string>
+    <string name="key_last_export_destination" translatable="false">last_export_destination</string>
+    <string name="key_use_compact_list" translatable="false">use_compact_list</string>
+    <string name="key_prefs_header_general" translatable="false">prefs_header_general</string>
+    <string name="key_dropbox_access_token" translatable="false">dropbox_access_token</string>
+    <string name="key_backup_location" translatable="false">backup_location</string>
+    <string name="key_export_accounts_csv" translatable="false">export_accounts_csv_key</string>
     <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
     <string name="label_backup_filename" translatable="false">gnucash_pocket_backup.gnca</string>
     <string name="playstore_url" translatable="false">"market://details?id=org.gnucash.pocket"</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -36,6 +36,8 @@
     <string name="key_prefs_header_general">prefs_header_general</string>
     <string name="key_dropbox_access_token">dropbox_access_token</string>
     <string name="key_backup_location">backup_location</string>
+    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
+    <string name="label_backup_filename" translatable="false">gnucash_pocket_backup.gnca</string>
     <string name="playstore_url" translatable="false">"market://details?id=org.gnucash.pocket"</string>
     <string-array name="key_transaction_type_values" translatable="false">
         <item>CREDIT</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,4 +497,7 @@
         <item>Tax</item>
         <item>Placeholder</item>
     </string-array>
+    <string name="action_transaction">transaction to</string>
+    <string name="action_backup">backup to</string>
+    <string name="schedule_export_desription" translatable="false">"%1$s %2$s %3$s"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -459,7 +459,6 @@
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>
     <string name="yes_sure">Yes, I\'m sure</string>
-    <string name="key_export_accounts_csv">export_accounts_csv_key</string>
     <string name="summary_export_accounts_csv">Export all accounts (without transactions) to CSV</string>
     <string name="title_export_accounts_csv">Export as CSV</string>
     <string name="label_csv_separator">Separator</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -455,8 +455,6 @@
     <string name="btn_restore">Restore</string>
     <string name="title_no_backups_found">No backups found</string>
     <string name="msg_no_backups_to_restore_from">There are no existing backup files to restore from</string>
-    <!-- This is the filename for default backups. So use only simple characters and no spaces. Do not change the extension -->
-    <string name="label_backup_filename">gnucash_android_backup.gnca</string>
     <string name="label_select_destination_after_export">Select the destination after export is complete</string>
     <string name="label_dropbox_export_destination">Export to \'/Apps/GnuCash Android/\' folder on Dropbox</string>
     <string name="title_section_preferences">Preferences</string>


### PR DESCRIPTION
```
Caused by java.lang.SecurityException: Permission Denial: opening provider com.google.android.apps.docs.common.storagebackend.StorageBackendContentProvider from ProcessRecord{476cf14 16544:org.gnucash.pocket.pnemonic/u0a256} (pid=16544, uid=10256) requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs
       at android.os.Parcel.createException(Parcel.java:2071)
       at android.os.Parcel.readException(Parcel.java:2039)
       at android.os.Parcel.readException(Parcel.java:1987)
       at android.app.IActivityManager$Stub$Proxy.getContentProvider(IActivityManager.java:5158)
       at android.app.ActivityThread.acquireProvider(ActivityThread.java:6808)
       at android.app.ContextImpl$ApplicationContentResolver.acquireUnstableProvider(ContextImpl.java:2762)
       at android.content.ContentResolver.acquireUnstableProvider(ContentResolver.java:2163)
       at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1523)
       at android.content.ContentResolver.openOutputStream(ContentResolver.java:1245)
       at android.content.ContentResolver.openOutputStream(ContentResolver.java:1221)
       at org.gnucash.android.util.BackupManager.backupBook(BackupManager.java:126)
       at org.gnucash.android.util.BackupManager.backupAllBooks(BackupManager.java:79)
       at org.gnucash.android.util.BackupJob.onHandleWork(BackupJob.java:46)
       at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:396)
       at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:387)
       at android.os.AsyncTask$3.call(AsyncTask.java:378)
       at java.util.concurrent.FutureTask.run(FutureTask.java:266)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:919)
```