### PR TITLE
fix build error when compiling with new JDK

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,8 @@
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+# The --add-exports flags are needed to be able to run the Butterknife annotation processor
+# with modern Java compilers. See https://stackoverflow.com/questions/71257962
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M" \
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
When compiling using a recent Android Studio and JDK the following error occurs:

```
superclass access check failed: class butterknife.compiler.ButterKnifeProcessor$RScanner (in unnamed module @0x65e8e2f6) cannot access class com.sun.tools.javac.tree.TreeScanner (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.tree to unnamed module @0x65e8e2f6
```

The patch adds compiler flags that workaround the issue.