### PR TITLE
ignore "Cannot perform this operation because there is no current tra…

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
+++ b/app/src/main/java/org/gnucash/android/db/MigrationHelper.java
@@ -394,8 +394,8 @@ public class MigrationHelper {
      */
     static int upgradeDbToVersion7(SQLiteDatabase db) {
         int oldVersion = 6;
-        db.beginTransaction();
         try {
+            db.beginTransaction();
             // backup transaction table
             db.execSQL("ALTER TABLE " + TransactionEntry.TABLE_NAME + " RENAME TO " + TransactionEntry.TABLE_NAME + "_bak");
             // create new transaction table
@@ -509,8 +509,8 @@ public class MigrationHelper {
         //start moving the files in background thread before we do the database stuff
         new Thread(moveExportedFilesToNewDefaultLocation).start();
 
-        db.beginTransaction();
         try {
+            db.beginTransaction();
             Timber.i("Creating scheduled actions table");
             db.execSQL("CREATE TABLE " + ScheduledActionEntry.TABLE_NAME + " ("
                     + ScheduledActionEntry._ID + " integer primary key autoincrement, "
@@ -867,8 +867,8 @@ public class MigrationHelper {
         Timber.i("Upgrading database to version 9");
         int oldVersion = 8;
 
-        db.beginTransaction();
         try {
+            db.beginTransaction();
             db.execSQL("CREATE TABLE " + CommodityEntry.TABLE_NAME + " ("
                     + CommodityEntry._ID + " integer primary key autoincrement, "
                     + CommodityEntry.COLUMN_UID + " varchar(255) not null UNIQUE, "
@@ -1097,8 +1097,8 @@ public class MigrationHelper {
         Timber.i("Upgrading database to version 9");
         int oldVersion = 9;
 
-        db.beginTransaction();
         try {
+            db.beginTransaction();
             Cursor cursor = db.query(ScheduledActionEntry.TABLE_NAME,
                     new String[]{ScheduledActionEntry.COLUMN_UID, ScheduledActionEntry.COLUMN_TAG},
                     ScheduledActionEntry.COLUMN_TYPE + " = ?",
@@ -1151,8 +1151,8 @@ public class MigrationHelper {
         Timber.i("Upgrading database to version 9");
         int oldVersion = 10;
 
-        db.beginTransaction();
         try {
+            db.beginTransaction();
             Cursor cursor = db.query(ScheduledActionEntry.TABLE_NAME, null,
                     ScheduledActionEntry.COLUMN_TYPE + "= ?",
                     new String[]{ScheduledAction.ActionType.BACKUP.name()}, null, null, null);
@@ -1249,8 +1249,8 @@ public class MigrationHelper {
         Timber.i("Upgrading database to version 13");
         int oldVersion = 12;
 
-        db.beginTransaction();
         try {
+            db.beginTransaction();
             db.execSQL("CREATE TABLE " + RecurrenceEntry.TABLE_NAME + " ("
                     + RecurrenceEntry._ID + " integer primary key autoincrement, "
                     + RecurrenceEntry.COLUMN_UID + " varchar(255) not null UNIQUE, "
@@ -1602,8 +1602,8 @@ public class MigrationHelper {
         Timber.i("Upgrading database to version 15");
         int dbVersion = 14;
 
-        db.beginTransaction();
         try {
+            db.beginTransaction();
             ContentValues contentValues = new ContentValues();
             contentValues.putNull(AccountEntry.COLUMN_DEFAULT_TRANSFER_ACCOUNT_UID);
             db.update(

--- a/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
@@ -383,8 +383,8 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         Timber.d("Delete account with rowId with its transactions and sub-accounts: %s", accountId);
 
         List<String> descendantAccountUIDs = getDescendantAccountUIDs(accountUID, null, null);
-        mDb.beginTransaction();
         try {
+            beginTransaction();
             descendantAccountUIDs.add(accountUID); //add account to descendants list just for convenience
             for (String descendantAccountUID : descendantAccountUIDs) {
                 mTransactionsAdapter.deleteTransactionsForAccount(descendantAccountUID);
@@ -409,10 +409,10 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
                         null);
             }
 
-            mDb.setTransactionSuccessful();
+            setTransactionSuccessful();
             return true;
         } finally {
-            mDb.endTransaction();
+            endTransaction();
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
@@ -293,19 +293,19 @@ public abstract class DatabaseAdapter<Model extends BaseModel> implements Closea
 
     public long bulkAddRecords(@NonNull List<Model> modelList, UpdateMethod updateMethod) {
         if (modelList.isEmpty()) {
-            Timber.d("Empty model list. Cannot bulk add records, returning 0");
+            Timber.w("Empty model list. Cannot bulk add records, returning 0");
             return 0;
         }
 
         Timber.i("Bulk adding %d %s records to the database", modelList.size(),
                 modelList.isEmpty() ? "null" : modelList.get(0).getClass().getSimpleName());
-        long nRow = 0;
+        long nRow;
         try {
-            mDb.beginTransaction();
+            beginTransaction();
             nRow = doAddModels(modelList, updateMethod);
-            mDb.setTransactionSuccessful();
+            setTransactionSuccessful();
         } finally {
-            mDb.endTransaction();
+            endTransaction();
         }
 
         return nRow;
@@ -829,7 +829,11 @@ public abstract class DatabaseAdapter<Model extends BaseModel> implements Closea
      * Expose mDb.endTransaction()
      */
     public void endTransaction() {
-        mDb.endTransaction();
+        try {
+            mDb.endTransaction();
+        } catch (Exception e) {
+            Timber.e(e);
+        }
     }
 
     @Override

--- a/app/src/main/java/org/gnucash/android/db/adapter/TransactionsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/TransactionsDbAdapter.java
@@ -104,8 +104,8 @@ public class TransactionsDbAdapter extends DatabaseAdapter<Transaction> {
     @Override
     public void addRecord(@NonNull Transaction transaction, UpdateMethod updateMethod) {
         Timber.d("Adding transaction to the db via %s", updateMethod.name());
-        mDb.beginTransaction();
         try {
+            beginTransaction();
             Split imbalanceSplit = transaction.createAutoBalanceSplit();
             if (imbalanceSplit != null) {
                 String imbalanceAccountUID = new AccountsDbAdapter(mDb, this)
@@ -133,11 +133,11 @@ public class TransactionsDbAdapter extends DatabaseAdapter<Transaction> {
                     new String[]{transaction.getUID()});
             Timber.d("%d splits deleted", deleted);
 
-            mDb.setTransactionSuccessful();
+            setTransactionSuccessful();
         } catch (SQLException e) {
             Timber.e(e);
         } finally {
-            mDb.endTransaction();
+            endTransaction();
         }
     }
 

--- a/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
+++ b/app/src/main/java/org/gnucash/android/importer/GncXmlHandler.java
@@ -973,9 +973,9 @@ public class GncXmlHandler extends DefaultHandler {
         //we on purpose do not set the book active. Only import. Caller should handle activation
 
         long startTime = System.nanoTime();
-        mAccountsDbAdapter.beginTransaction();
         Timber.d("bulk insert starts");
         try {
+            mAccountsDbAdapter.beginTransaction();
             // disable foreign key. The database structure should be ensured by the data inserted.
             // it will make insertion much faster.
             mAccountsDbAdapter.enableForeignKey(false);

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -866,9 +866,9 @@ public class TransactionFormFragment extends Fragment implements
         }
 
         mTransaction = transaction;
-        mAccountsDbAdapter.beginTransaction();
 
         try {
+            mAccountsDbAdapter.beginTransaction();
             // 1) mTransactions may be existing or non-existing
             // 2) when mTransactions exists in the db, the splits may exist or not exist in the db
             // So replace is chosen.


### PR DESCRIPTION
```
Caused by java.lang.IllegalStateException: Cannot perform this operation because there is no current transaction.
       at android.database.sqlite.SQLiteSession.throwIfNoTransaction(SQLiteSession.java:917)
       at android.database.sqlite.SQLiteSession.endTransaction(SQLiteSession.java:400)
       at android.database.sqlite.SQLiteDatabase.endTransaction(SQLiteDatabase.java:755)
       at org.gnucash.android.db.adapter.DatabaseAdapter.bulkAddRecords(DatabaseAdapter.java:308)
       at org.gnucash.android.db.adapter.TransactionsDbAdapter.bulkAddRecords(TransactionsDbAdapter.java:157)
       at org.gnucash.android.service.ScheduledActionService.executeTransactions(ScheduledActionService.java:260)
       at org.gnucash.android.service.ScheduledActionService.executeScheduledEvent(ScheduledActionService.java:136)
       at org.gnucash.android.service.ScheduledActionService.processScheduledActions(ScheduledActionService.java:121)
       at org.gnucash.android.service.ScheduledActionService.onHandleWork(ScheduledActionService.java:88)
       at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:396)
       at androidx.core.app.JobIntentService$CommandProcessor.doInBackground(JobIntentService.java:387)
       at android.os.AsyncTask$3.call(AsyncTask.java:394)
       at java.util.concurrent.FutureTask.run(FutureTask.java:264)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```