### PR TITLE
Disable bundle split for languages.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,6 +136,13 @@ android {
         }
     }
 
+    bundle {
+        language {
+            // This is disabled so that the App Bundle does NOT split the APK for each language.
+            // We're gonna use the same APK for all languages.
+            enableSplit false
+        }
+    }
 
     compileOptions { //we want switch with strings during xml parsing
         encoding "UTF-8"


### PR DESCRIPTION
Google Play store complains about missing language "gr".

https://stackoverflow.com/questions/57859122/invalid-splitapkbundle-the-bundle-targets-unknown-languages-gr-google-play