### PR TITLE
fix broken split transaction fragment

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/util/widget/CalculatorEditText.java
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/CalculatorEditText.java
@@ -75,7 +75,8 @@ public class CalculatorEditText extends AppCompatEditText {
     }
 
     public CalculatorEditText(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+        super(context, attrs);
+        init(context, attrs);
     }
 
     public CalculatorEditText(Context context, AttributeSet attrs, int defStyleAttr) {


### PR DESCRIPTION
In #92  an error was introduced, which instantiated the AppCompatEditText with the defStyleAttr value of zero. This broke the edit text view, which led to crashes if the calculator keyboard was used.