### PR TITLE
"colors array and labels array need to be of same size"

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/report/barchart/StackedBarChartFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/report/barchart/StackedBarChartFragment.java
@@ -52,7 +52,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -211,7 +210,7 @@ public class StackedBarChartFragment extends BaseReportFragment {
 
         BarDataSet set = new BarDataSet(values, "");
         set.setDrawValues(false);
-        set.setStackLabels(labels.toArray(new String[labels.size()]));
+        set.setStackLabels(labels.toArray(new String[0]));
         set.setColors(colors);
 
         if (getYValueSum(set) == 0) {
@@ -327,11 +326,11 @@ public class StackedBarChartFragment extends BaseReportFragment {
         Legend legend = mChart.getLegend();
         IBarDataSet dataSet = mChart.getData().getDataSetByIndex(0);
 
-        LinkedHashSet<String> labels = new LinkedHashSet<>(Arrays.asList(dataSet.getStackLabels()));
-        LinkedHashSet<Integer> colors = new LinkedHashSet<>(dataSet.getColors());
+        List<Integer> colors = dataSet.getColors();
+        List<String> labels = Arrays.asList(dataSet.getStackLabels());
 
-        if (COLORS.length >= labels.size()) {
-            legend.setCustom(new ArrayList<>(colors), new ArrayList<>(labels));
+        if (colors.size() == labels.size()) {
+            legend.setCustom(colors, labels);
             return;
         }
         legend.setEnabled(false);


### PR DESCRIPTION
```
Caused by java.lang.IllegalArgumentException: colors array and labels array need to be of same size
       at com.github.mikephil.charting.components.Legend.setCustom(Legend.java:322)
       at org.gnucash.android.ui.report.barchart.StackedBarChartFragment.setCustomLegend(StackedBarChartFragment.java:334)
       at org.gnucash.android.ui.report.barchart.StackedBarChartFragment.generateReport(StackedBarChartFragment.java:302)
       at org.gnucash.android.ui.report.BaseReportFragment$1.doInBackground(BaseReportFragment.java:297)
       at org.gnucash.android.ui.report.BaseReportFragment$1.doInBackground(BaseReportFragment.java:288)
       at android.os.AsyncTask$3.call(AsyncTask.java:378)
       at java.util.concurrent.FutureTask.run(FutureTask.java:266)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:289)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:919)
```