### PR TITLE
Dropbox access tokens empty?

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,9 +97,8 @@ android {
             resValue "string", "app_name", "GnuCash-devel"
             resValue "string", "app_version_name", "${versionName}"
 
-            resValue "string", "dropbox_app_key", "dhjh8ke9wf05948"
-            resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
-            resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
+            buildConfigField "String", "DROPBOX_APP_KEY", "\"dhjh8ke9wf05948\""
+            manifestPlaceholders.dropbox_app_key = "db-dhjh8ke9wf05948"
         }
 
         beta {
@@ -108,13 +107,11 @@ android {
             resValue "string", "app_version_name", "${versionName}"
 
             if (project.hasProperty("RELEASE_DROPBOX_APP_KEY")) {
-                resValue "string", "dropbox_app_key", RELEASE_DROPBOX_APP_KEY
-                resValue "string", "dropbox_app_secret", RELEASE_DROPBOX_APP_SECRET
-                resValue "string", "manifest_dropbox_app_key", "db-${RELEASE_DROPBOX_APP_KEY}"
+                buildConfigField "String", "DROPBOX_APP_KEY", "\"${RELEASE_DROPBOX_APP_KEY}\""
+                manifestPlaceholders.dropbox_app_key = "db-${RELEASE_DROPBOX_APP_KEY}"
             } else {
-                resValue "string", "dropbox_app_key", "dhjh8ke9wf05948"
-                resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
-                resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
+                buildConfigField "String", "DROPBOX_APP_KEY", "\"dhjh8ke9wf05948\""
+                manifestPlaceholders.dropbox_app_key = "db-dhjh8ke9wf05948"
             }
         }
 
@@ -123,13 +120,11 @@ android {
             resValue "string", "app_name", "GnuCash"
 
             if (project.hasProperty("RELEASE_DROPBOX_APP_KEY")) {
-                resValue "string", "dropbox_app_key", RELEASE_DROPBOX_APP_KEY
-                resValue "string", "dropbox_app_secret", RELEASE_DROPBOX_APP_SECRET
-                resValue "string", "manifest_dropbox_app_key", "db-${RELEASE_DROPBOX_APP_KEY}"
+                buildConfigField "String", "DROPBOX_APP_KEY", "\"${RELEASE_DROPBOX_APP_KEY}\""
+                manifestPlaceholders.dropbox_app_key = "db-${RELEASE_DROPBOX_APP_KEY}"
             } else {
-                resValue "string", "dropbox_app_key", "dhjh8ke9wf05948"
-                resValue "string", "dropbox_app_secret", "h2t9fphj3nr4wkw"
-                resValue "string", "manifest_dropbox_app_key", "db-dhjh8ke9wf05948"
+                buildConfigField "String", "DROPBOX_APP_KEY", "\"dhjh8ke9wf05948\""
+                manifestPlaceholders.dropbox_app_key = "db-dhjh8ke9wf05948"
             }
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -113,7 +113,7 @@
             android:exported="true">
             <intent-filter>
                 <!-- Change this to be db- followed by your app key -->
-                <data android:scheme="@string/manifest_dropbox_app_key" />
+                <data android:scheme="${dropbox_app_key}" />
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/org/gnucash/android/export/DropboxHelper.java
+++ b/app/src/main/java/org/gnucash/android/export/DropboxHelper.java
@@ -35,6 +35,8 @@ import org.gnucash.android.R;
  */
 public class DropboxHelper {
 
+    private static final String DROPBOX_APP_KEY = BuildConfig.DROPBOX_APP_KEY;
+
     /**
      * DropBox API v2 client for making requests to DropBox
      */
@@ -67,8 +69,10 @@ public class DropboxHelper {
             return sDbxClient;
 
         String accessToken = getAccessToken(context);
-        if (TextUtils.isEmpty(accessToken))
+        if (TextUtils.isEmpty(accessToken)) {
+            DropboxHelper.authenticate(context);
             return null;
+        }
 
         DbxRequestConfig config = new DbxRequestConfig(BuildConfig.APPLICATION_ID);
         sDbxClient = new DbxClientV2(config, accessToken);
@@ -113,7 +117,6 @@ public class DropboxHelper {
     }
 
     public static void authenticate(Context context) {
-        String dropboxAppKey = context.getString(R.string.dropbox_app_key);
-        Auth.startOAuth2Authentication(context, dropboxAppKey);
+        Auth.startOAuth2Authentication(context, DROPBOX_APP_KEY);
     }
 }

--- a/app/src/main/java/org/gnucash/android/ui/export/ExportFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/export/ExportFormFragment.java
@@ -58,7 +58,6 @@ import com.codetroopers.betterpickers.radialtimepicker.RadialTimePickerDialogFra
 import com.codetroopers.betterpickers.recurrencepicker.EventRecurrence;
 import com.codetroopers.betterpickers.recurrencepicker.EventRecurrenceFormatter;
 import com.codetroopers.betterpickers.recurrencepicker.RecurrencePickerDialogFragment;
-import com.dropbox.core.android.Auth;
 
 import org.gnucash.android.R;
 import org.gnucash.android.app.GnuCashApplication;
@@ -78,7 +77,6 @@ import org.gnucash.android.ui.settings.dialog.OwnCloudDialogFragment;
 import org.gnucash.android.ui.transaction.TransactionFormFragment;
 import org.gnucash.android.ui.util.RecurrenceParser;
 import org.gnucash.android.ui.util.RecurrenceViewClickListener;
-import org.gnucash.android.util.ContentExtKt;
 import org.gnucash.android.util.PreferencesHelper;
 import org.gnucash.android.util.TimestampHelper;
 
@@ -296,7 +294,7 @@ public class ExportFormFragment extends Fragment implements
     @Override
     public void onResume() {
         super.onResume();
-        DropboxHelper.retrieveAndSaveToken();
+        DropboxHelper.retrieveAndSaveToken(requireContext());
     }
 
     @Override
@@ -305,7 +303,7 @@ public class ExportFormFragment extends Fragment implements
         // When the user try to export sharing to 3rd party service like DropBox
         // then pausing all activities. That cause passcode screen appearing happened.
         // We use a disposable flag to skip this unnecessary passcode screen.
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         prefs.edit().putBoolean(UxArgument.SKIP_PASSCODE_SCREEN, true).apply();
     }
 
@@ -374,10 +372,9 @@ public class ExportFormFragment extends Fragment implements
                         setExportUriText(getString(R.string.label_dropbox_export_destination));
                         mRecurrenceOptionsView.setVisibility(View.VISIBLE);
                         mExportParams.setExportTarget(ExportParams.ExportTarget.DROPBOX);
-                        String dropboxAppKey = getString(R.string.dropbox_app_key, BackupPreferenceFragment.DROPBOX_APP_KEY);
 
-                        if (!DropboxHelper.hasToken()) {
-                            Auth.startOAuth2Authentication(context, dropboxAppKey);
+                        if (!DropboxHelper.hasToken(context)) {
+                            DropboxHelper.authenticate(context);
                         }
                         break;
                     case 2: //OwnCloud


### PR DESCRIPTION
```
          Caused by java.lang.NullPointerException: accessToken
       at com.dropbox.core.v2.DbxClientV2$DbxUserRawClientV2.<init>(DbxClientV2.java:70)
       at com.dropbox.core.v2.DbxClientV2.<init>(DbxClientV2.java:47)
       at com.dropbox.core.v2.DbxClientV2.<init>(DbxClientV2.java:31)
       at org.gnucash.android.export.DropboxHelper.getClient(DropboxHelper.java:82)
       at org.gnucash.android.export.ExportAsyncTask.moveExportToDropbox(ExportAsyncTask.java:363)
       at org.gnucash.android.export.ExportAsyncTask.moveToTarget(ExportAsyncTask.java:254)
       at org.gnucash.android.export.ExportAsyncTask.doInBackground(ExportAsyncTask.java:159)
       at org.gnucash.android.export.ExportAsyncTask.doInBackground(ExportAsyncTask.java:90)
       at android.os.AsyncTask$3.call(AsyncTask.java:394)
       at java.util.concurrent.FutureTask.run(FutureTask.java:264)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
        
```