### PR TITLE
Avoid "FOREIGN KEY constraint failed" for price.

### DIFF
--- a/app/src/main/kotlin/org/gnucash/android/model/Price.kt
+++ b/app/src/main/kotlin/org/gnucash/android/model/Price.kt
@@ -40,9 +40,7 @@ class Price : BaseModel {
      */
     constructor(commodity1: Commodity?, commodity2: Commodity?, exchangeRate: BigDecimal) :
             this(commodity1, commodity2) {
-        // Store 0.1234 as 1234/10000
-        valueNum = exchangeRate.unscaledValue().toLong()
-        valueDenom = BigDecimal.ONE.scaleByPowerOfTen(exchangeRate.scale()).toLong()
+        setExchangeRate(exchangeRate)
     }
 
     private var _valueNum = 0L
@@ -128,6 +126,12 @@ class Price : BaseModel {
 
     val commodityUID: String? get() = commodity?.uID
     val currencyUID: String? get() = currency?.uID
+
+    fun setExchangeRate(rate: BigDecimal) {
+        // Store 0.1234 as 1234/10000
+        valueNum = rate.unscaledValue().toLong()
+        valueDenom = BigDecimal.ONE.scaleByPowerOfTen(rate.scale()).toLong()
+    }
 
     companion object {
         /**


### PR DESCRIPTION
```
Fatal Exception: android.database.sqlite.SQLiteConstraintException: FOREIGN KEY constraint failed (code 787 SQLITE_CONSTRAINT_FOREIGNKEY[787])
       at android.database.sqlite.SQLiteConnection.nativeExecute(SQLiteConnection.java)
       at android.database.sqlite.SQLiteConnection.execute(SQLiteConnection.java:1034)
       at android.database.sqlite.SQLiteSession.execute(SQLiteSession.java:621)
       at android.database.sqlite.SQLiteStatement.execute(SQLiteStatement.java:47)
       at org.gnucash.android.db.adapter.DatabaseAdapter.addRecord(DatabaseAdapter.java:244)
       at org.gnucash.android.db.adapter.DatabaseAdapter.addRecord(DatabaseAdapter.java:215)
       at org.gnucash.android.ui.transaction.dialog.TransferFundsDialogFragment.transferFunds(TransferFundsDialogFragment.java:224)
       at org.gnucash.android.ui.transaction.dialog.TransferFundsDialogFragment.-$$Nest$mtransferFunds()
       at org.gnucash.android.ui.transaction.dialog.TransferFundsDialogFragment$4.onClick(TransferFundsDialogFragment.java:183)
       at androidx.appcompat.app.AlertController$ButtonHandler.handleMessage(AlertController.java:167)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:230)
       at android.os.Looper.loop(Looper.java:319)
       at android.app.ActivityThread.main(ActivityThread.java:9063)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:588)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
```