### PR TITLE
Can reload list when fragment attached.

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/account/AccountsListFragment.java
@@ -316,6 +316,7 @@ public class AccountsListFragment extends MenuFragment implements
      */
     @Override
     public void refresh() {
+        if (isDetached() || getFragmentManager() == null) return;
         getLoaderManager().restartLoader(0, null, this);
     }
 
@@ -399,7 +400,7 @@ public class AccountsListFragment extends MenuFragment implements
             return true;
         }
         mCurrentFilter = newFilter;
-        getLoaderManager().restartLoader(0, null, this);
+        refresh();
         return true;
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/budget/BudgetListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/budget/BudgetListFragment.java
@@ -142,6 +142,7 @@ public class BudgetListFragment extends Fragment implements Refreshable,
 
     @Override
     public void refresh() {
+        if (isDetached() || getFragmentManager() == null) return;
         getLoaderManager().restartLoader(0, null, this);
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/settings/BookManagerFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/settings/BookManagerFragment.java
@@ -149,6 +149,7 @@ public class BookManagerFragment extends ListFragment implements
 
     @Override
     public void refresh() {
+        if (isDetached() || getFragmentManager() == null) return;
         getLoaderManager().restartLoader(0, null, this);
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/ScheduledActionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/ScheduledActionsListFragment.java
@@ -90,6 +90,7 @@ public abstract class ScheduledActionsListFragment extends MenuFragment implemen
 
     @Override
     public void refresh() {
+        if (isDetached() || getFragmentManager() == null) return;
         getLoaderManager().restartLoader(0, null, this);
     }
 

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsListFragment.java
@@ -163,6 +163,7 @@ public class TransactionsListFragment extends MenuFragment implements
      */
     @Override
     public void refresh() {
+        if (isDetached() || getFragmentManager() == null) return;
         getLoaderManager().restartLoader(0, null, this);
     }
 


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalStateException: Can't access ViewModels from detached fragment
       at androidx.fragment.app.Fragment.getViewModelStore(Fragment.java:414)
       at androidx.loader.app.LoaderManager.getInstance(LoaderManager.java:128)
       at androidx.fragment.app.Fragment.getLoaderManager(Fragment.java:1425)
       at org.gnucash.android.ui.account.AccountsListFragment.refresh(AccountsListFragment.java:319)
       at org.gnucash.android.ui.account.AccountsListFragment.lambda$tryDeleteAccount$0(AccountsListFragment.java:261)
       at org.gnucash.android.ui.account.AccountsListFragment.$r8$lambda$rXxyQAMaXqiegwYU5GZCPqetBfY()
       at org.gnucash.android.ui.account.AccountsListFragment$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass)
       at org.gnucash.android.util.BackupManager$1.onPostExecute(BackupManager.java:252)
       at org.gnucash.android.util.BackupManager$1.onPostExecute(BackupManager.java:218)
       at android.os.AsyncTask.finish(AsyncTask.java:771)
       at android.os.AsyncTask.-$$Nest$mfinish()
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:211)
       at android.os.Looper.loop(Looper.java:300)
       at android.app.ActivityThread.main(ActivityThread.java:8410)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:559)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:954)
```