### PR TITLE
QIF export denomination

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,7 +189,7 @@ dependencies {
     implementation('com.google.android.material:material:1.12.0')
     implementation('androidx.cardview:cardview:1.0.0')
     implementation('androidx.preference:preference-ktx:1.2.1')
-    implementation('androidx.recyclerview:recyclerview:1.3.2')
+    implementation('androidx.recyclerview:recyclerview:1.4.0')
     implementation("androidx.work:work-runtime-ktx:2.10.0")
 
     implementation 'net.objecthunter:exp4j:0.4.7'
@@ -199,7 +199,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-drive:17.0.0'
 
     // Logging
-    implementation 'com.google.firebase:firebase-crashlytics:19.3.0'
+    implementation 'com.google.firebase:firebase-crashlytics:19.4.0'
     implementation "com.jakewharton.timber:timber:5.0.1"
 
     implementation 'com.github.nextcloud:android-library:1.0.31'
@@ -221,7 +221,7 @@ dependencies {
     // Debug
     debugImplementation 'com.facebook.stetho:stetho:1.5.0'
 
-    testImplementation 'org.robolectric:robolectric:4.14.1'
+    testImplementation 'org.robolectric:robolectric:4.13'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 

--- a/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
+++ b/app/src/androidTest/java/org/gnucash/android/test/ui/TransactionsActivityTest.java
@@ -664,8 +664,8 @@ public class TransactionsActivityTest {
 
         for (Transaction transaction : transactions) {
             if (transaction.getDescription().equals("Power intents")) {
-                assertThat("Intents for sale").isEqualTo(transaction.getNote());
-                assertThat(4.99).isEqualTo(transaction.getBalance(TRANSACTIONS_ACCOUNT_UID).toDouble());
+                assertThat(transaction.getNote()).isEqualTo("Intents for sale");
+                assertThat(transaction.getBalance(TRANSACTIONS_ACCOUNT_UID).toDouble()).isEqualTo(4.99);
             }
         }
     }

--- a/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
@@ -880,7 +880,6 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
         Timber.d("all account list : %d", accountsList.size());
         SplitsDbAdapter splitsDbAdapter = mTransactionsAdapter.getSplitDbAdapter();
         return splitsDbAdapter.computeSplitBalance(accountsList, currencyCode, hasDebitNormalBalance, startTimestamp, endTimestamp);
-
     }
 
     /**

--- a/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
+++ b/app/src/main/java/org/gnucash/android/export/ExportAsyncTask.java
@@ -273,7 +273,7 @@ public class ExportAsyncTask extends AsyncTask<ExportParams, Void, Integer> {
             return;
         }
 
-        if (exportedFiles.size() > 0) {
+        if (!exportedFiles.isEmpty()) {
             try {
                 OutputStream outputStream = mContext.getContentResolver().openOutputStream(exportUri);
                 // Now we always get just one file exported (multi-currency QIFs are zipped)

--- a/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
+++ b/app/src/main/java/org/gnucash/android/export/xml/GncXmlExporter.java
@@ -59,6 +59,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -295,7 +296,7 @@ public class GncXmlExporter extends Exporter {
         while (cursor.moveToNext()) {
             String curTrxUID = cursor.getString(cursor.getColumnIndexOrThrow("trans_uid"));
             if (!lastTrxUID.equals(curTrxUID)) { // new transaction starts
-                if (!lastTrxUID.equals("")) { // there's an old transaction, close it
+                if (!TextUtils.isEmpty(lastTrxUID)) { // there's an old transaction, close it
                     xmlSerializer.endTag(null, TAG_TRN_SPLITS);
                     xmlSerializer.endTag(null, TAG_TRANSACTION);
                 }
@@ -854,7 +855,7 @@ public class GncXmlExporter extends Exporter {
                 // Feature not supported. No problem
             }
             xmlSerializer.setOutput(writer);
-            xmlSerializer.startDocument("utf-8", true);
+            xmlSerializer.startDocument(StandardCharsets.UTF_8.name(), true);
             // root tag
             xmlSerializer.startTag(null, TAG_ROOT);
             for (String ns : namespaces) {

--- a/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/homescreen/WidgetConfigurationActivity.java
@@ -305,7 +305,7 @@ public class WidgetConfigurationActivity extends Activity {
         } else {
             Money accountBalance = accountsDbAdapter.getAccountBalance(accountUID, -1, System.currentTimeMillis());
             views.setTextViewText(R.id.transactions_summary,
-                accountBalance.formattedString(Locale.getDefault()));
+                accountBalance.formattedString());
             int color = accountBalance.isNegative() ? R.color.debit_red : R.color.credit_green;
             views.setTextColor(R.id.transactions_summary, ContextCompat.getColor(context, color));
         }

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -193,6 +193,8 @@ public class TransactionFormFragment extends MenuFragment implements
     @Nullable
     private FragmentTransactionFormBinding mBinding;
 
+    private final CommoditiesDbAdapter commoditiesDbAdapter = CommoditiesDbAdapter.getInstance();
+
     /**
      * Create the view and retrieve references to the UI elements
      */
@@ -684,16 +686,15 @@ public class TransactionFormFragment extends MenuFragment implements
         BigDecimal enteredAmount = binding.inputTransactionAmount.getValue();
         if (enteredAmount == null) enteredAmount = BigDecimal.ZERO;
         String baseCurrencyCode = mTransactionsDbAdapter.getAccountCurrencyCode(mAccountUID);
-        Money value = new Money(enteredAmount, Commodity.getInstance(baseCurrencyCode));
+        Money value = new Money(enteredAmount, commoditiesDbAdapter.getCommodity(baseCurrencyCode));
         Money quantity = new Money(value);
 
         String transferAcctUID = getTransferAccountUID(binding);
-        CommoditiesDbAdapter cmdtyDbAdapter = CommoditiesDbAdapter.getInstance();
 
         if (isMultiCurrencyTransaction(binding)) { //if multi-currency transaction
             String transferCurrencyCode = mAccountsDbAdapter.getCurrencyCode(transferAcctUID);
-            String commodityUID = cmdtyDbAdapter.getCommodityUID(baseCurrencyCode);
-            String targetCmdtyUID = cmdtyDbAdapter.getCommodityUID(transferCurrencyCode);
+            String commodityUID = commoditiesDbAdapter.getCommodityUID(baseCurrencyCode);
+            String targetCmdtyUID = commoditiesDbAdapter.getCommodityUID(transferCurrencyCode);
 
             if ((value.equals(mSplitValue)) && mSplitQuantity != null) {
                 quantity = mSplitQuantity;
@@ -704,7 +705,7 @@ public class TransactionFormFragment extends MenuFragment implements
                 if (pricePair.first > 0 && pricePair.second > 0) {
                     quantity = quantity.times(pricePair.first.intValue())
                         .div(pricePair.second.intValue())
-                        .withCurrency(cmdtyDbAdapter.getRecord(targetCmdtyUID));
+                        .withCurrency(commoditiesDbAdapter.getRecord(targetCmdtyUID));
                 }
             }
         }
@@ -772,7 +773,7 @@ public class TransactionFormFragment extends MenuFragment implements
         String description = binding.inputTransactionName.getText().toString();
         String notes = binding.inputDescription.getText().toString();
         String currencyCode = mAccountsDbAdapter.getAccountCurrencyCode(mAccountUID);
-        Commodity commodity = CommoditiesDbAdapter.getInstance().getCommodity(currencyCode);
+        Commodity commodity = commoditiesDbAdapter.getCommodity(currencyCode);
 
         List<Split> splits = extractSplitsFromView(binding);
 

--- a/app/src/main/java/org/gnucash/android/ui/util/TextInputResetError.kt
+++ b/app/src/main/java/org/gnucash/android/ui/util/TextInputResetError.kt
@@ -1,0 +1,18 @@
+package org.gnucash.android.ui.util
+
+import android.text.Editable
+import android.text.TextWatcher
+import com.google.android.material.textfield.TextInputLayout
+
+/**
+ * Hides the error message when the user edits the content.
+ */
+class TextInputResetError(private vararg val inputs: TextInputLayout) : TextWatcher {
+    override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+        inputs.forEach { it.isErrorEnabled = false }
+    }
+
+    override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) = Unit
+
+    override fun afterTextChanged(s: Editable) = Unit
+}

--- a/app/src/main/kotlin/org/gnucash/android/export/ofx/OfxExporter.kt
+++ b/app/src/main/kotlin/org/gnucash/android/export/ofx/OfxExporter.kt
@@ -45,6 +45,7 @@ import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import timber.log.Timber
+import java.nio.charset.StandardCharsets
 
 /**
  * Exports the data in the database in OFX format.
@@ -138,7 +139,7 @@ class OfxExporter(context: Context, params: ExportParams, bookUID: String) :
         var writer: BufferedWriter? = null
         try {
             val file = File(exportCacheFilePath)
-            writer = BufferedWriter(OutputStreamWriter(FileOutputStream(file), "UTF-8"))
+            writer = BufferedWriter(OutputStreamWriter(FileOutputStream(file), StandardCharsets.UTF_8))
             writer.write(generateOfxExport(accounts))
             close()
         } catch (e: IOException) {

--- a/app/src/main/kotlin/org/gnucash/android/model/Commodity.kt
+++ b/app/src/main/kotlin/org/gnucash/android/model/Commodity.kt
@@ -17,6 +17,7 @@ package org.gnucash.android.model
 
 import java.util.TimeZone
 import org.gnucash.android.db.adapter.CommoditiesDbAdapter
+import kotlin.math.log10
 
 /**
  * Commodities are the currencies used in the application.
@@ -97,7 +98,7 @@ class Commodity(
         get() = if (smallestFraction == 0) {
             0
         } else {
-            Integer.numberOfTrailingZeros(smallestFraction)
+            numberOfTrailingZeros(smallestFraction)
         }
 
     /**
@@ -212,6 +213,13 @@ class Commodity(
                 return currencyCode
             }
             return "$currencyCode ($name)"
+        }
+
+        @JvmStatic
+        fun numberOfTrailingZeros(value: Number): Int {
+            val v = value.toDouble()
+            if (v <= 1) return 0
+            return log10(v).toInt()
         }
     }
 

--- a/app/src/main/kotlin/org/gnucash/android/model/Price.kt
+++ b/app/src/main/kotlin/org/gnucash/android/model/Price.kt
@@ -49,7 +49,7 @@ class Price : BaseModel {
             _valueNum = value
             reduce(value, valueDenom)
         }
-    private var _valueDenom = 0L
+    private var _valueDenom = 1L
     var valueDenom: Long
         get() = _valueDenom
         set(value) {
@@ -107,8 +107,10 @@ class Price : BaseModel {
     override fun toString(): String {
         val numerator = BigDecimal(valueNum)
         val denominator = BigDecimal(valueDenom)
-        val formatter = NumberFormat.getNumberInstance() as DecimalFormat
-        formatter.maximumFractionDigits = 6
+        val precision = currency.smallestFractionDigits
+        val formatter = (NumberFormat.getNumberInstance() as DecimalFormat).apply {
+            maximumFractionDigits = precision
+        }
         return formatter.format(numerator.divide(denominator, MathContext.DECIMAL32))
     }
 

--- a/app/src/main/res/layout/dialog_transfer_funds.xml
+++ b/app/src/main/res/layout/dialog_transfer_funds.xml
@@ -13,155 +13,160 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:focusableInTouchMode="true"
-    android:orientation="vertical">
+    android:fillViewport="true">
 
-    <TableRow android:padding="@dimen/dialog_padding">
-
-        <TextView
-            android:id="@+id/amount_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/label_transaction_amount"
-            android:textSize="16sp" />
-
-        <TextView
-            android:id="@+id/amount_to_convert"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:textSize="18sp"
-            tools:text="$ 2000.00" />
-    </TableRow>
-
-    <TableRow android:padding="@dimen/dialog_padding">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/label_convert_from"
-            android:textSize="16sp" />
-
-        <TextView
-            android:id="@+id/from_currency"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_weight="1"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            tools:text="USD" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="@string/label_convert_to"
-            android:textSize="16sp" />
-
-        <TextView
-            android:id="@+id/to_currency"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_weight="1"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            tools:text="EUR" />
-    </TableRow>
-
-    <TextView
+    <TableLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/dialog_padding"
-        android:text="@string/msg_provide_exchange_rate" />
+        android:focusableInTouchMode="true"
+        android:orientation="vertical">
 
-    <TableRow
-        android:gravity="center_vertical"
-        android:padding="@dimen/dialog_padding">
+        <TableRow android:padding="@dimen/dialog_padding">
 
-        <RadioButton
-            android:id="@+id/radio_exchange_rate"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="false" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/exchange_rate_text_input_layout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
-
-            <EditText
-                android:id="@+id/input_exchange_rate"
-                android:layout_width="match_parent"
+            <TextView
+                android:id="@+id/amount_label"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:text="@string/label_transaction_amount"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/amount_to_convert"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:textSize="18sp"
+                tools:text="$ 2000.00" />
+        </TableRow>
+
+        <TableRow android:padding="@dimen/dialog_padding">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/label_convert_from"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/from_currency"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                tools:text="USD" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="@string/label_convert_to"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/to_currency"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                tools:text="EUR" />
+        </TableRow>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/dialog_padding"
+            android:text="@string/msg_provide_exchange_rate" />
+
+        <TableRow
+            android:gravity="center_vertical"
+            android:padding="@dimen/dialog_padding">
+
+            <RadioButton
+                android:id="@+id/radio_exchange_rate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="false" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/exchange_rate_text_input_layout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+
+                <EditText
+                    android:id="@+id/input_exchange_rate"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:enabled="false"
+                    android:hint="@string/hint_exchange_rate"
+                    android:inputType="numberDecimal" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- TODO: re-enable this button when fetching of price quotes is implemented -->
+            <Button
+                android:id="@+id/btn_fetch_exchange_rate"
+                style="?attr/borderlessButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:enabled="false"
-                android:hint="@string/hint_exchange_rate"
-                android:inputType="numberDecimal" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <!-- TODO: re-enable this button when fetching of price quotes is implemented -->
-        <Button
-            android:id="@+id/btn_fetch_exchange_rate"
-            style="?attr/borderlessButtonStyle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:enabled="false"
-            android:imeOptions="actionDone"
-            android:text="@string/btn_fetch_quote"
-            android:textColor="@color/theme_accent"
-            android:visibility="gone" />
-    </TableRow>
-
-    <TextView
-        android:id="@+id/label_exchange_rate_example"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:paddingStart="@dimen/dialog_padding"
-        android:paddingEnd="@dimen/dialog_padding"
-        android:paddingBottom="@dimen/dialog_padding"
-        tools:text="1 USD = 1.34 EUR" />
-
-    <TableRow
-        android:gravity="center_vertical"
-        android:padding="@dimen/dialog_padding">
-
-        <RadioButton
-            android:id="@+id/radio_converted_amount"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="true" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/converted_amount_text_input_layout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
-
-            <EditText
-                android:id="@+id/input_converted_amount"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/hint_converted_amount"
-                android:inputType="numberDecimal">
-
-                <requestFocus />
-            </EditText>
-        </com.google.android.material.textfield.TextInputLayout>
+                android:text="@string/btn_fetch_quote"
+                android:textColor="@color/theme_accent"
+                android:visibility="gone" />
+        </TableRow>
 
         <TextView
-            android:id="@+id/target_currency"
-            android:layout_width="wrap_content"
+            android:id="@+id/label_exchange_rate_example"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:textSize="16sp"
-            tools:text="EUR" />
-    </TableRow>
-</TableLayout>
+            android:paddingStart="@dimen/dialog_padding"
+            android:paddingEnd="@dimen/dialog_padding"
+            android:paddingBottom="@dimen/dialog_padding"
+            tools:text="1 USD = 1.34 EUR" />
+
+        <TableRow
+            android:gravity="center_vertical"
+            android:padding="@dimen/dialog_padding">
+
+            <RadioButton
+                android:id="@+id/radio_converted_amount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/converted_amount_text_input_layout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+
+                <EditText
+                    android:id="@+id/input_converted_amount"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hint_converted_amount"
+                    android:inputType="numberDecimal">
+
+                    <requestFocus />
+                </EditText>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:id="@+id/target_currency"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textSize="16sp"
+                tools:text="EUR" />
+        </TableRow>
+    </TableLayout>
+</ScrollView>

--- a/app/src/test/java/org/gnucash/android/test/unit/GnuCashTest.kt
+++ b/app/src/test/java/org/gnucash/android/test/unit/GnuCashTest.kt
@@ -8,14 +8,12 @@ import org.robolectric.annotation.Config
 import timber.log.Timber
 
 @RunWith(RobolectricTestRunner::class) //package is required so that resources can be found in dev mode
-
-//package is required so that resources can be found in dev mode
 @Config(sdk = [21], shadows = [ShadowCrashlytics::class])
 abstract class GnuCashTest {
     companion object {
         @JvmStatic
         @BeforeClass
-        fun before(): Unit {
+        fun before() {
             Timber.plant(ConsoleTree())
         }
     }

--- a/app/src/test/java/org/gnucash/android/test/unit/db/AccountsDbAdapterTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/db/AccountsDbAdapterTest.java
@@ -16,7 +16,6 @@
 package org.gnucash.android.test.unit.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import android.database.sqlite.SQLiteDatabase;
 
@@ -119,7 +118,7 @@ public class AccountsDbAdapterTest extends GnuCashTest {
         mAccountsDbAdapter.addRecord(first);
 
         List<Account> accountsList = mAccountsDbAdapter.getAllRecords();
-        assertEquals(2, accountsList.size());
+        assertThat(accountsList.size()).isEqualTo(2);
         //bravo was saved first, but alpha should be first alphabetically
         assertThat(accountsList).contains(first, Index.atIndex(0));
         assertThat(accountsList).contains(second, Index.atIndex(1));

--- a/app/src/test/java/org/gnucash/android/test/unit/model/MoneyTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/MoneyTest.java
@@ -18,7 +18,7 @@ package org.gnucash.android.test.unit.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.within;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 
@@ -36,14 +36,14 @@ import java.util.Locale;
 
 public class MoneyTest extends GnuCashTest {
 
-    private static final String CURRENCY_CODE = "EUR";
+    private static final String CURRENCY_EUR = "EUR";
     private Money mMoneyInEur;
     private int mHashcode;
     private String amountString = "15.75";
 
     @Before
     public void setUp() throws Exception {
-        mMoneyInEur = new Money(new BigDecimal(amountString), Commodity.getInstance(CURRENCY_CODE));
+        mMoneyInEur = new Money(new BigDecimal(amountString), Commodity.getInstance(CURRENCY_EUR));
         mHashcode = mMoneyInEur.hashCode();
     }
 
@@ -52,23 +52,23 @@ public class MoneyTest extends GnuCashTest {
         Locale.setDefault(Locale.US);
         String amount = "12.25";
 
-        Money temp = new Money(amount, CURRENCY_CODE);
-        assertThat("12.25").isEqualTo(temp.toPlainString());
+        Money temp = new Money(amount, CURRENCY_EUR);
+        assertThat(temp.toPlainString()).isEqualTo("12.25");
         assertThat(temp.getNumerator()).isEqualTo(1225L);
         assertThat(temp.getDenominator()).isEqualTo(100L);
 
-        Commodity commodity = Commodity.getInstance(CURRENCY_CODE);
+        Commodity commodity = Commodity.getInstance(CURRENCY_EUR);
         temp = new Money(BigDecimal.TEN, commodity);
 
-        assertEquals("10.00", temp.asBigDecimal().toPlainString()); //decimal places for EUR currency
-        assertEquals(commodity, temp.getCommodity());
-        assertThat("10").isNotEqualTo(temp.asBigDecimal().toPlainString());
+        assertThat(temp.asBigDecimal().toPlainString()).isEqualTo("10.00"); //decimal places for EUR currency
+        assertThat(temp.getCommodity()).isEqualTo(commodity);
+        assertThat(temp.asBigDecimal().toPlainString()).isNotEqualTo("10");
     }
 
     @Test
     public void testAddition() {
-        Money result = mMoneyInEur.plus(new Money("5", CURRENCY_CODE));
-        assertEquals("20.75", result.toPlainString());
+        Money result = mMoneyInEur.plus(new Money("5", CURRENCY_EUR));
+        assertThat(result.toPlainString()).isEqualTo("20.75");
         assertNotSame(result, mMoneyInEur);
         validateImmutability();
     }
@@ -81,8 +81,8 @@ public class MoneyTest extends GnuCashTest {
 
     @Test
     public void testSubtraction() {
-        Money result = mMoneyInEur.minus(new Money("2", CURRENCY_CODE));
-        assertEquals(new BigDecimal("13.75"), result.asBigDecimal());
+        Money result = mMoneyInEur.minus(new Money("2", CURRENCY_EUR));
+        assertThat(result.asBigDecimal()).isEqualTo(new BigDecimal("13.75"));
         assertNotSame(result, mMoneyInEur);
         validateImmutability();
     }
@@ -95,7 +95,7 @@ public class MoneyTest extends GnuCashTest {
 
     @Test
     public void testMultiplication() {
-        Money result = mMoneyInEur.times(new Money(BigDecimal.TEN, Commodity.getInstance(CURRENCY_CODE)));
+        Money result = mMoneyInEur.times(new Money(BigDecimal.TEN, Commodity.getInstance(CURRENCY_EUR)));
         assertThat("157.50").isEqualTo(result.toPlainString());
         assertThat(result).isNotEqualTo(mMoneyInEur);
         validateImmutability();
@@ -148,41 +148,41 @@ public class MoneyTest extends GnuCashTest {
 
     @Test
     public void testPrinting() {
-        assertEquals(mMoneyInEur.asString(), mMoneyInEur.toPlainString());
-        assertEquals(amountString, mMoneyInEur.asString());
+        assertThat(mMoneyInEur.toPlainString()).isEqualTo(mMoneyInEur.asString());
+        assertThat(mMoneyInEur.asString()).isEqualTo(amountString);
 
         // the unicode for Euro symbol is \u20AC
 
         String symbol = Currency.getInstance("EUR").getSymbol(Locale.GERMANY);
-        String actualOuputDE = mMoneyInEur.formattedString(Locale.GERMANY);
-        assertThat(actualOuputDE).isEqualTo("15,75 " + symbol);
+        String actualOutputDE = mMoneyInEur.formattedString(Locale.GERMANY);
+        assertThat(actualOutputDE).isEqualTo("15,75 " + symbol);
 
         symbol = Currency.getInstance("EUR").getSymbol(Locale.GERMANY);
-        String actualOuputUS = mMoneyInEur.formattedString(Locale.US);
-        assertThat(actualOuputUS).isEqualTo(symbol + "15.75");
+        String actualOutputUS = mMoneyInEur.formattedString(Locale.US);
+        assertThat(actualOutputUS).isEqualTo(symbol + "15.75");
 
         //always prints with 2 decimal places only
-        Money some = new Money("9.7469", CURRENCY_CODE);
-        assertEquals("9.75", some.asString());
+        Money some = new Money("9.7469", CURRENCY_EUR);
+        assertThat(some.asString()).isEqualTo("9.75");
     }
 
     public void validateImmutability() {
-        assertEquals(mHashcode, mMoneyInEur.hashCode());
-        assertEquals(amountString, mMoneyInEur.toPlainString());
+        assertThat(mMoneyInEur.hashCode()).isEqualTo(mHashcode);
+        assertThat(mMoneyInEur.toPlainString()).isEqualTo(amountString);
         assertNotNull(mMoneyInEur.getCommodity());
-        assertEquals(CURRENCY_CODE, mMoneyInEur.getCommodity().getCurrencyCode());
+        assertThat(mMoneyInEur.getCommodity().getCurrencyCode()).isEqualTo(CURRENCY_EUR);
     }
 
     @Test
     public void overflow() {
-        Money rounding = new Money("12345678901234567.89", CURRENCY_CODE);
-        assertThat("12345678901234567.89").isEqualTo(rounding.toPlainString());
-        assertThat("€12,345,678,901,234,567.89").isEqualTo(rounding.formattedString(Locale.US));
+        Money rounding = new Money("12345678901234567.89", CURRENCY_EUR);
+        assertThat(rounding.toPlainString()).isEqualTo("12345678901234567.89");
         assertThat(rounding.getNumerator()).isEqualTo(1234567890123456789L);
         assertThat(rounding.getDenominator()).isEqualTo(100L);
+        assertThat(rounding.formattedString(Locale.US)).isEqualTo("€12,345,678,901,234,567.89");
 
-        Money overflow = new Money("1234567890123456789.00", CURRENCY_CODE);
-        assertThat("1234567890123456789.00").isEqualTo(overflow.toPlainString());
+        Money overflow = new Money("1234567890123456789.00", CURRENCY_EUR);
+        assertThat(overflow.toPlainString()).isEqualTo("1234567890123456789.00");
         assertThatThrownBy(() -> overflow.getNumerator()).isInstanceOf(ArithmeticException.class);
     }
 
@@ -191,8 +191,8 @@ public class MoneyTest extends GnuCashTest {
     public void evaluate_25() {
         BigDecimal value = AmountParser.evaluate("123456789012345678.90");
         assertNotNull(value);
-        assertEquals(123456789012345678.90, value.doubleValue(), 1e-2);
-        assertEquals(123456789012345680L, value.longValue());
+        assertThat(value.doubleValue()).isCloseTo(123456789012345678.90, within(1e-2));
+        assertThat(value.longValue()).isEqualTo(123456789012345680L);
     }
 
     @Test
@@ -200,7 +200,7 @@ public class MoneyTest extends GnuCashTest {
     public void evaluate_26() {
         BigDecimal value = AmountParser.evaluate("123456789012345678.90");
         assertNotNull(value);
-        assertEquals(123456789012345678.90, value.doubleValue(), 1e-2);
-        assertEquals(123456789012345678L, value.longValue());
+        assertThat(value.doubleValue()).isCloseTo(123456789012345678.90, within(1e-2));
+        assertThat(value.longValue()).isEqualTo(123456789012345678L);
     }
 }

--- a/app/src/test/java/org/gnucash/android/test/unit/model/PriceTest.java
+++ b/app/src/test/java/org/gnucash/android/test/unit/model/PriceTest.java
@@ -34,16 +34,18 @@ public class PriceTest {
         Commodity commodity1 = Commodity.USD;
         Commodity commodity2 = Commodity.EUR;
 
-        String exchangeRateString = "0.123456";
+        String exchangeRateString = "0.123";
         BigDecimal exchangeRate = new BigDecimal(exchangeRateString);
         Price price = new Price(commodity1, commodity2, exchangeRate);
-        assertThat(price.toString()).isEqualTo(exchangeRateString);
+        // EUR uses 2 fractional digits.
+        assertThat(price.toString()).isEqualTo("0.12");
 
         // ensure we don't get more decimal places than needed (0.123000)
-        exchangeRateString = "0.123";
+        exchangeRateString = "0.123456";
         exchangeRate = new BigDecimal(exchangeRateString);
         price = new Price(commodity1, commodity2, exchangeRate);
-        assertThat(price.toString()).isEqualTo(exchangeRateString);
+        // EUR uses 2 fractional digits.
+        assertThat(price.toString()).isEqualTo("0.12");
     }
 
     @Test
@@ -55,7 +57,8 @@ public class PriceTest {
         String exchangeRateString = "1.234";
         BigDecimal exchangeRate = new BigDecimal(exchangeRateString);
         Price price = new Price(commodity1, commodity2, exchangeRate);
-        assertThat(price.toString()).isEqualTo("1,234");
+        // USD uses 2 fractional digits.
+        assertThat(price.toString()).isEqualTo("1,23");
     }
 
     /**


### PR DESCRIPTION
Fixes issue #98 for the QIF export.

```
org.gnucash.android.export.Exporter$ExporterException: Failed to generate export with parameters: Export all transactions created since 2025-01-01 12:32:31.917 UTC as QIF to SHARING - split quantity has illegal denominator: 100000000
	at org.gnucash.android.export.qif.QifExporter.generateExport(QifExporter.java:222)
	at org.gnucash.android.export.ExportAsyncTask.doInBackground(ExportAsyncTask.java:135)
	at org.gnucash.android.export.ExportAsyncTask.doInBackground(ExportAsyncTask.java:87)

```