### PR TITLE
Reduce "Record does not exist in the db"

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/AccountsDbAdapter.java
@@ -26,6 +26,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
+import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
@@ -1349,7 +1350,7 @@ public class AccountsDbAdapter extends DatabaseAdapter<Account> {
     }
 
     @Override
-    public boolean deleteRecord(@NonNull String uid) {
+    public boolean deleteRecord(@NonNull String uid) throws SQLException {
         boolean result = super.deleteRecord(uid);
         if (result) {
             ContentValues contentValues = new ContentValues();

--- a/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
@@ -542,7 +542,7 @@ public abstract class DatabaseAdapter<Model extends BaseModel> implements Closea
      * @param rowId ID of record to be deleted
      * @return <code>true</code> if deletion was successful, <code>false</code> otherwise
      */
-    public boolean deleteRecord(long rowId) {
+    public boolean deleteRecord(long rowId) throws SQLException {
         Timber.d("Deleting record with id " + rowId + " from " + mTableName);
         return mDb.delete(mTableName, DatabaseSchema.CommonColumns._ID + "=" + rowId, null) > 0;
     }
@@ -755,7 +755,7 @@ public abstract class DatabaseAdapter<Model extends BaseModel> implements Closea
      * @return <code>true</code> if deletion was successful, <code>false</code> otherwise
      * @see #deleteRecord(long)
      */
-    public boolean deleteRecord(@NonNull String uid) {
+    public boolean deleteRecord(@NonNull String uid) throws SQLException {
         return deleteRecord(getID(uid));
     }
 


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalArgumentException: accounts with GUID 10223989ddcabf496a16f5b4c390b4e1 does not exist in the db
       at org.gnucash.android.db.adapter.DatabaseAdapter.getID(DatabaseAdapter.java:577)
       at org.gnucash.android.db.adapter.DatabaseAdapter.deleteRecord(DatabaseAdapter.java:759)
       at org.gnucash.android.db.adapter.AccountsDbAdapter.deleteRecord(AccountsDbAdapter.java:1355)
       at org.gnucash.android.ui.account.AccountsListFragment.lambda$tryDeleteAccount$0(AccountsListFragment.java:262)
       at org.gnucash.android.ui.account.AccountsListFragment.$r8$lambda$rXxyQAMaXqiegwYU5GZCPqetBfY()
       at org.gnucash.android.ui.account.AccountsListFragment$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass)
       at org.gnucash.android.util.BackupManager$1.onPostExecute(BackupManager.java:252)
       at org.gnucash.android.util.BackupManager$1.onPostExecute(BackupManager.java:218)
       at android.os.AsyncTask.finish(AsyncTask.java:771)
       at android.os.AsyncTask.access$900(AsyncTask.java:199)
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:257)
       at android.app.ActivityThread.main(ActivityThread.java:8333)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:603)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```