### PR TITLE
database is locked?

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionFormFragment.java
@@ -857,8 +857,6 @@ public class TransactionFormFragment extends MenuFragment implements
         mTransaction = transaction;
 
         try {
-            mTransactionsDbAdapter.beginTransaction();
-
             if (isTemplate) { //template is automatically checked when a transaction is scheduled
                 if (mEditMode && wasScheduled) {
                     transaction.setScheduledActionUID(scheduledActionUID);
@@ -880,16 +878,12 @@ public class TransactionFormFragment extends MenuFragment implements
                 scheduledActionDbAdapter.deleteRecord(scheduledActionUID);
             }
 
-            mTransactionsDbAdapter.setTransactionSuccessful();
-
             finish(Activity.RESULT_OK);
         } catch (ArithmeticException ae) {
             Timber.e(ae);
             binding.inputTransactionAmount.setError(getString(R.string.error_invalid_amount));
         } catch (Throwable e) {
             Timber.e(e);
-        } finally {
-            mTransactionsDbAdapter.endTransaction();
         }
     }
 


### PR DESCRIPTION
```
23:41:16.861  E  android.database.sqlite.SQLiteDatabaseLockedException: database is locked (code 5 SQLITE_BUSY)
                 	at android.database.sqlite.SQLiteConnection.nativeExecute(Native Method)
                 	at android.database.sqlite.SQLiteConnection.execute(SQLiteConnection.java:757)
                 	at android.database.sqlite.SQLiteSession.beginTransactionUnchecked(SQLiteSession.java:336)
                 	at android.database.sqlite.SQLiteSession.beginTransaction(SQLiteSession.java:311)
                 	at android.database.sqlite.SQLiteDatabase.beginTransaction(SQLiteDatabase.java:819)
                 	at android.database.sqlite.SQLiteDatabase.beginTransaction(SQLiteDatabase.java:802)
                 	at android.database.sqlite.SQLiteDatabase.beginTransaction(SQLiteDatabase.java:653)
                 	at org.gnucash.android.db.adapter.DatabaseAdapter.beginTransaction(DatabaseAdapter.java:878)
                 	at org.gnucash.android.ui.transaction.TransactionFormFragment.saveNewTransaction(TransactionFormFragment.java:875)
                 	at org.gnucash.android.ui.transaction.TransactionFormFragment.onOptionsItemSelected(TransactionFormFragment.java:978)
                 	at org.gnucash.android.app.MenuFragment$menuProvider$1.onMenuItemSelected(MenuFragment.kt:28)
                 	at androidx.core.view.MenuHostHelper.onMenuItemSelected(MenuHostHelper.java:108)
                 	at androidx.activity.ComponentActivity.onMenuItemSelected(ComponentActivity.kt:465)
                 	at androidx.fragment.app.FragmentActivity.onMenuItemSelected(FragmentActivity.java:265)
                 	at androidx.appcompat.app.AppCompatActivity.onMenuItemSelected(AppCompatActivity.java:256)
                 	at androidx.appcompat.view.WindowCallbackWrapper.onMenuItemSelected(WindowCallbackWrapper.java:109)
                 	at androidx.appcompat.app.ToolbarActionBar$2.onMenuItemClick(ToolbarActionBar.java:66)
                 	at androidx.appcompat.widget.Toolbar$1.onMenuItemClick(Toolbar.java:224)
                 	at androidx.appcompat.widget.ActionMenuView$MenuBuilderCallback.onMenuItemSelected(ActionMenuView.java:769)
                 	at androidx.appcompat.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:833)
                 	at androidx.appcompat.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:157)
                 	at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:984)
                 	at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:974)
                 	at androidx.appcompat.widget.ActionMenuView.invokeItem(ActionMenuView.java:620)
                 	at androidx.appcompat.view.menu.ActionMenuItemView.onClick(ActionMenuItemView.java:155)
                 	at android.view.View.performClick(View.java:8119)
                 	at android.view.View.performClickInternal(View.java:8089)
                 	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
                 	at android.view.View$PerformClick.run(View.java:31890)
                 	at android.os.Handler.handleCallback(Handler.java:973)
                 	at android.os.Handler.dispatchMessage(Handler.java:100)
                 	at android.os.Looper.loopOnce(Looper.java:282)
                 	at android.os.Looper.loop(Looper.java:387)
                 	at android.app.ActivityThread.main(ActivityThread.java:9500)
                 	at java.lang.reflect.Method.invoke(Native Method)
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1005)
23:41:16.864  E  java.lang.IllegalStateException: Cannot perform this operation because there is no current transaction.
                 	at android.database.sqlite.SQLiteSession.throwIfNoTransaction(SQLiteSession.java:1021)
                 	at android.database.sqlite.SQLiteSession.endTransaction(SQLiteSession.java:419)
                 	at android.database.sqlite.SQLiteDatabase.endTransaction(SQLiteDatabase.java:833)
                 	at org.gnucash.android.db.adapter.DatabaseAdapter.endTransaction(DatabaseAdapter.java:907)
                 	at org.gnucash.android.ui.transaction.TransactionFormFragment.saveNewTransaction(TransactionFormFragment.java:907)
                 	at org.gnucash.android.ui.transaction.TransactionFormFragment.onOptionsItemSelected(TransactionFormFragment.java:978)
                 	at org.gnucash.android.app.MenuFragment$menuProvider$1.onMenuItemSelected(MenuFragment.kt:28)
                 	at androidx.core.view.MenuHostHelper.onMenuItemSelected(MenuHostHelper.java:108)
                 	at androidx.activity.ComponentActivity.onMenuItemSelected(ComponentActivity.kt:465)
                 	at androidx.fragment.app.FragmentActivity.onMenuItemSelected(FragmentActivity.java:265)
                 	at androidx.appcompat.app.AppCompatActivity.onMenuItemSelected(AppCompatActivity.java:256)
                 	at androidx.appcompat.view.WindowCallbackWrapper.onMenuItemSelected(WindowCallbackWrapper.java:109)
                 	at androidx.appcompat.app.ToolbarActionBar$2.onMenuItemClick(ToolbarActionBar.java:66)
                 	at androidx.appcompat.widget.Toolbar$1.onMenuItemClick(Toolbar.java:224)
                 	at androidx.appcompat.widget.ActionMenuView$MenuBuilderCallback.onMenuItemSelected(ActionMenuView.java:769)
                 	at androidx.appcompat.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:833)
                 	at androidx.appcompat.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:157)
                 	at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:984)
                 	at androidx.appcompat.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:974)
                 	at androidx.appcompat.widget.ActionMenuView.invokeItem(ActionMenuView.java:620)
                 	at androidx.appcompat.view.menu.ActionMenuItemView.onClick(ActionMenuItemView.java:155)
                 	at android.view.View.performClick(View.java:8119)
                 	at android.view.View.performClickInternal(View.java:8089)
                 	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
                 	at android.view.View$PerformClick.run(View.java:31890)
                 	at android.os.Handler.handleCallback(Handler.java:973)
                 	at android.os.Handler.dispatchMessage(Handler.java:100)
                 	at android.os.Looper.loopOnce(Looper.java:282)
                 	at android.os.Looper.loop(Looper.java:387)
                 	at android.app.ActivityThread.main(ActivityThread.java:9500)
                 	at java.lang.reflect.Method.invoke(Native Method)
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1005)

```