### PR TITLE
Record not found in transactions

### DIFF
--- a/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
+++ b/app/src/main/java/org/gnucash/android/db/adapter/DatabaseAdapter.java
@@ -782,7 +782,12 @@ public abstract class DatabaseAdapter<Model extends BaseModel> implements Closea
      */
     public boolean deleteRecord(@NonNull String uid) throws SQLException {
         if (isCached) cache.remove(uid);
-        return deleteRecord(getID(uid));
+        try {
+            return deleteRecord(getID(uid));
+        } catch (IllegalArgumentException e) {
+            Timber.e(e);
+            return false;
+        }
     }
 
     public boolean deleteRecord(@NonNull Model model) throws SQLException {


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalArgumentException: Record not found in transactions
       at org.gnucash.android.db.adapter.DatabaseAdapter.getID(DatabaseAdapter.java:658)
       at org.gnucash.android.db.adapter.DatabaseAdapter.deleteRecord(DatabaseAdapter.java:784)
       at org.gnucash.android.ui.transaction.ScheduledTransactionsViewHolder.deleteSchedule(ScheduledTransactionsViewHolder.kt:88)
       at org.gnucash.android.ui.transaction.ScheduledViewHolder.onMenuItemClick$lambda$1(ScheduledViewHolder.kt:73)
       at org.gnucash.android.ui.transaction.ScheduledViewHolder.$r8$lambda$_epRRWydNWXXzU2HI7NsG3mlQK8()
       at org.gnucash.android.ui.transaction.ScheduledViewHolder$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass)
       at org.gnucash.android.util.BackupManager$1.onPostExecute(BackupManager.java:248)
       at org.gnucash.android.util.BackupManager$1.onPostExecute(BackupManager.java:214)
       at android.os.AsyncTask.finish(AsyncTask.java:771)
       at android.os.AsyncTask.access$900(AsyncTask.java:199)
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:210)
       at android.os.Looper.loop(Looper.java:299)
       at android.app.ActivityThread.main(ActivityThread.java:8319)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:556)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1038)
```