### PR TITLE
Form type required

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/common/FormActivity.java
+++ b/app/src/main/java/org/gnucash/android/ui/common/FormActivity.java
@@ -16,8 +16,6 @@
 
 package org.gnucash.android.ui.common;
 
-import android.content.Intent;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.MenuItem;
@@ -40,6 +38,8 @@ import org.gnucash.android.ui.passcode.PasscodeLockActivity;
 import org.gnucash.android.ui.transaction.SplitEditorFragment;
 import org.gnucash.android.ui.transaction.TransactionFormFragment;
 import org.gnucash.android.util.BookUtils;
+
+import timber.log.Timber;
 
 /**
  * Activity for displaying forms in the application.
@@ -69,10 +69,15 @@ public class FormActivity extends PasscodeLockActivity {
         binding = ActivityFormBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        final Intent intent = getIntent();
+        final Bundle args = getIntent().getExtras();
+        if (args == null) {
+            Timber.e("Arguments required");
+            finish();
+            return;
+        }
 
         //if a parameter was passed to open an account within a specific book, then switch
-        String bookUID = intent.getStringExtra(UxArgument.BOOK_UID);
+        String bookUID = args.getString(UxArgument.BOOK_UID);
         if (bookUID != null && !bookUID.equals(GnuCashApplication.getActiveBookUID())) {
             BookUtils.activateBook(this, bookUID);
         }
@@ -84,9 +89,6 @@ public class FormActivity extends PasscodeLockActivity {
         actionBar.setHomeButtonEnabled(true);
         actionBar.setDisplayHomeAsUpEnabled(true);
 
-        Bundle args = intent.getExtras();
-        if (args == null) args = new Bundle();
-
         mAccountUID = args.getString(UxArgument.SELECTED_ACCOUNT_UID);
         if (TextUtils.isEmpty(mAccountUID)) {
             mAccountUID = args.getString(UxArgument.PARENT_ACCOUNT_UID);
@@ -97,6 +99,11 @@ public class FormActivity extends PasscodeLockActivity {
         }
 
         String formtypeString = args.getString(UxArgument.FORM_TYPE);
+        if (TextUtils.isEmpty(formtypeString)) {
+            Timber.e("No form display type specified");
+            finish();
+            return;
+        }
         FormType formType = FormType.valueOf(formtypeString);
         switch (formType) {
             case ACCOUNT:


### PR DESCRIPTION
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equals(java.lang.Object)' on a null object reference
       at java.lang.Enum.valueOf(Enum.java:252)
       at org.gnucash.android.ui.common.FormActivity$FormType.valueOf(FormActivity.java:57)
       at org.gnucash.android.ui.common.FormActivity.onCreate(FormActivity.java:100)
       at android.app.Activity.performCreate(Activity.java:7994)
       at android.app.Activity.performCreate(Activity.java:7978)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1548)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3406)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3607)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2068)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:223)
       at android.app.ActivityThread.main(ActivityThread.java:7680)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:423)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```