### PR TITLE
Hide non-critical activities.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,9 +39,6 @@
         android:name="${applicationId}.permission.CREATE_ACCOUNT"
         android:label="@string/label_permission_create_accounts" />
 
-    <uses-permission
-        android:name="android.permission.VIBRATE"
-        android:label="Allow device to vibrate with notifications" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission
         android:name="android.permission.RECEIVE_BOOT_COMPLETED"
@@ -59,7 +56,7 @@
         android:largeHeap="true"
         android:theme="@style/Theme.GnuCash.NoActionBar">
         <activity
-            android:name=".ui.account.AccountsActivity"
+            android:name="org.gnucash.android.ui.account.AccountsActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -100,16 +97,22 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ui.passcode.PasscodeLockScreenActivity"
+            android:name="org.gnucash.android.ui.passcode.PasscodeLockScreenActivity"
+            android:exported="false"
             android:noHistory="true"
             android:windowSoftInputMode="stateAlwaysHidden" />
-        <activity android:name=".ui.transaction.ScheduledActionsActivity" />
         <activity
-            android:name=".ui.passcode.PasscodePreferenceActivity"
+            android:name="org.gnucash.android.ui.transaction.ScheduledActionsActivity"
+            android:exported="false" />
+        <activity
+            android:name="org.gnucash.android.ui.passcode.PasscodePreferenceActivity"
+            android:exported="false"
             android:theme="@style/Theme.GnuCash.NoActionBar" />
-        <activity android:name=".ui.transaction.TransactionsActivity" />
         <activity
-            android:name=".ui.homescreen.WidgetConfigurationActivity"
+            android:name="org.gnucash.android.ui.transaction.TransactionsActivity"
+            android:exported="false" />
+        <activity
+            android:name="org.gnucash.android.ui.homescreen.WidgetConfigurationActivity"
             android:excludeFromRecents="true"
             android:exported="true"
             android:label="@string/label_widget_configuration"
@@ -119,24 +122,30 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ui.common.FormActivity"
-            android:configChanges="orientation|screenSize" />
+            android:name="org.gnucash.android.ui.common.FormActivity"
+            android:configChanges="orientation|screenSize"
+            android:exported="false" />
         <activity
-            android:name=".ui.transaction.TransactionDetailActivity"
-            android:configChanges="orientation|screenSize" />
+            android:name="org.gnucash.android.ui.transaction.TransactionDetailActivity"
+            android:configChanges="orientation|screenSize"
+            android:exported="false" />
         <activity
-            android:name=".ui.report.ReportsActivity"
+            android:name="org.gnucash.android.ui.report.ReportsActivity"
+            android:exported="false"
             android:label="@string/title_reports"
             android:launchMode="singleTop" />
         <activity
-            android:name=".ui.budget.BudgetsActivity"
+            android:name="org.gnucash.android.ui.budget.BudgetsActivity"
+            android:exported="false"
             android:launchMode="singleTop" />
         <activity
-            android:name=".ui.wizard.FirstRunWizardActivity"
+            android:name="org.gnucash.android.ui.wizard.FirstRunWizardActivity"
+            android:exported="false"
             android:label="@string/title_setup_gnucash"
             android:theme="@style/Theme.GnuCash" />
         <activity
-            android:name=".ui.settings.PreferenceActivity"
+            android:name="org.gnucash.android.ui.settings.PreferenceActivity"
+            android:exported="false"
             android:label="@string/title_settings"
             android:theme="@style/Theme.GnuCash" />
         <activity
@@ -154,7 +163,7 @@
         </activity>
 
         <receiver
-            android:name=".receivers.TransactionRecorder"
+            android:name="org.gnucash.android.receivers.TransactionRecorder"
             android:exported="true"
             android:label="Records transactions received through intents"
             android:permission="${applicationId}.permission.RECORD_TRANSACTION">
@@ -165,7 +174,7 @@
             </intent-filter>
         </receiver>
         <receiver
-            android:name=".receivers.AccountCreator"
+            android:name="org.gnucash.android.receivers.AccountCreator"
             android:enabled="true"
             android:exported="true"
             android:label="Creates new accounts"
@@ -177,7 +186,7 @@
             </intent-filter>
         </receiver>
         <receiver
-            android:name=".receivers.TransactionAppWidgetProvider"
+            android:name="org.gnucash.android.receivers.TransactionAppWidgetProvider"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.kt
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionDetailActivity.kt
@@ -34,7 +34,6 @@ import org.gnucash.android.ui.util.displayBalance
 import org.gnucash.android.util.BackupManager.backupActiveBookAsync
 import org.gnucash.android.util.formatFullDate
 import timber.log.Timber
-import java.util.MissingFormatArgumentException
 
 /**
  * Activity for displaying transaction information
@@ -61,7 +60,7 @@ class TransactionDetailActivity : PasscodeLockActivity(), FragmentResultListener
         accountUID = intent.getStringExtra(UxArgument.SELECTED_ACCOUNT_UID)
 
         if (transactionUID.isNullOrEmpty() || accountUID.isNullOrEmpty()) {
-            throw MissingFormatArgumentException("You must specify both the transaction and account UID")
+            throw IllegalArgumentException("Both the transaction and account UID are required")
         }
 
         setSupportActionBar(binding.toolbar)

--- a/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.kt
+++ b/app/src/main/java/org/gnucash/android/ui/transaction/TransactionsActivity.kt
@@ -509,9 +509,7 @@ class TransactionsActivity : BaseDrawerActivity(),
             Timber.e(e)
         }
         if (account == null) {
-            Timber.e("Account not found")
-            finish()
-            throw NullPointerException("Account required")
+            throw IllegalArgumentException("Account required")
         }
         return account
     }


### PR DESCRIPTION
```
Caused by java.util.MissingFormatArgumentException: Format specifier 'You must specify both the transaction and account UID'
       at org.gnucash.android.ui.transaction.TransactionDetailActivity.onCreate(TransactionDetailActivity.kt:64)
       at android.app.Activity.performCreate(Activity.java:8305)
       at android.app.Activity.performCreate(Activity.java:8284)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1417)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3626)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3782)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2307)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7872)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```