### PR TITLE
The specified child already has a parent.

### DIFF
--- a/app/src/main/java/org/gnucash/android/ui/util/widget/FragmentViewHolder.kt
+++ b/app/src/main/java/org/gnucash/android/ui/util/widget/FragmentViewHolder.kt
@@ -44,6 +44,11 @@ class FragmentViewHolder private constructor(
                     if (f == fragment) {
                         fm.unregisterFragmentLifecycleCallbacks(this)
                         if (v.parent === container) return
+                        if (v.parent is ViewGroup) {
+                            (v.parent as ViewGroup).removeView(v)
+                        } else if (v.parent != null) {
+                            return
+                        }
                         container.removeAllViews()
                         container.addView(v)
                         fragment.setMenuVisibility(layoutPosition == pager.currentItem)


### PR DESCRIPTION
```
Fatal Exception: java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
       at android.view.ViewGroup.addViewInner(ViewGroup.java:6084)
       at android.view.ViewGroup.addView(ViewGroup.java:5903)
       at android.view.ViewGroup.addView(ViewGroup.java:5843)
       at android.view.ViewGroup.addView(ViewGroup.java:5815)
       at org.gnucash.android.ui.util.widget.FragmentViewHolder$bind$1.onFragmentViewCreated(FragmentViewHolder.kt:48)
       at androidx.fragment.app.FragmentLifecycleCallbacksDispatcher.dispatchOnFragmentViewCreated(FragmentLifecycleCallbacksDispatcher.java:179)
       at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:553)
       at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:261)
       at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:1899)
       at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1817)
       at androidx.fragment.app.FragmentManager.execSingleAction(FragmentManager.java:1729)
       at androidx.fragment.app.BackStackRecord.commitNowAllowingStateLoss(BackStackRecord.java:323)
       at org.gnucash.android.ui.util.widget.FragmentViewHolder.bind(FragmentViewHolder.kt:64)
       at org.gnucash.android.ui.util.widget.FragmentStateAdapter.onBindViewHolder(FragmentStateAdapter.kt:62)
       at org.gnucash.android.ui.util.widget.FragmentStateAdapter.onBindViewHolder(FragmentStateAdapter.kt:14)
       at androidx.recyclerview.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:7846)
       at androidx.recyclerview.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:7953)
       at androidx.recyclerview.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:6742)
       at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:7013)
       at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6853)
       at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:6849)
       at androidx.recyclerview.widget.LinearLayoutManager$LayoutState.next(LinearLayoutManager.java:2422)
       at androidx.recyclerview.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java:1722)
       at androidx.recyclerview.widget.LinearLayoutManager.fill(LinearLayoutManager.java:1682)
       at androidx.recyclerview.widget.LinearLayoutManager.scrollBy(LinearLayoutManager.java:1485)
       at androidx.recyclerview.widget.LinearLayoutManager.scrollHorizontallyBy(LinearLayoutManager.java:1205)
       at androidx.recyclerview.widget.RecyclerView.scrollStep(RecyclerView.java:2158)
       at androidx.recyclerview.widget.RecyclerView$SmoothScroller.onAnimation(RecyclerView.java:13043)
       at androidx.recyclerview.widget.RecyclerView$ViewFlinger.run(RecyclerView.java:6019)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1108)
       at android.view.Choreographer.doCallbacks(Choreographer.java:866)
       at android.view.Choreographer.doFrame(Choreographer.java:792)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1092)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8751)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
        
```